### PR TITLE
Scoverage added + general refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
-  - "2.10.4"
-  - "2.11.2"
+  - "2.11.5"
 jdk:
   - openjdk7
   - oraclejdk8
-sbt_args: -no-colors
+
+script: sbt -no-colors ++$TRAVIS_SCALA_VERSION clean coverage test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+Contributing
+============
+
+All kind of tips & tricks for people interested in contributing to beholder.
+
+CI job
+------
+
+A Travis job is set up for `beholder` [here](https://travis-ci.org/VirtusLab/beholder).
+Each branch and PR is cross-tested against `Scala 2.11.5`, `OpenJDK 7` and `OpenJDK 8`.
+
+Code coverage
+-------------
+
+Beholder uses [scoverage](https://github.com/scoverage/scalac-scoverage-plugin) plugin for code coverage.
+To run it, use:
+
+```
+sbt clean coverage test
+```
+
+(`clean` *is important*)
+
+Results are placed in `beholder\target\scala-2.11\scoverage-report`.
+
+Minimum coverage is set to *48%* (which is current coverage) so all code you add to project *have to be 100% test-covered*, otherwise Travis build will fail.
+
+Releasing
+---------
+
+Before release you must have access to Sonatype and have PGP keys for signing artifacts. 
+For make release just use `+publishSigned +releaseSonatype`. 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Beholder: Play-Slick library for data presentation
-=========================
+==================================================
+[![Build Status](https://travis-ci.org/VirtusLab/beholder.svg?branch=master)](https://travis-ci.org/VirtusLab/beholder)
 
 Standard part of many application are list of data that is not a effect of simple query from one table but junction and aggregation of data from many tables. Beholder provides support for such elemets.
 
 Features:
 * views as table
 * declaring filters for data
-* suport for sorting, filtering on mutliple (custom) datatype
-
+* support for sorting, filtering on multiple (custom) datatypes
 
 Contributors
 ------------
@@ -22,10 +22,10 @@ Feel free to use it, test it and to contribute!
 Getting beholder
 ----------------
 
-For latest version (Scala 2.10.4/2.11.2 compatible) use:
+For latest version (Scala 2.11.5 compatible) use:
 
 ```scala
-libraryDependencies += "org.virtuslab" %% "beholder" % "0.2.0"
+libraryDependencies += "org.virtuslab" %% "beholder" % "0.2.2"
 ```
 
 Or see Maven repository for [2.10](http://maven-repository.com/artifact/org.virtuslab/beholder_2.10) and [2.11](http://maven-repository.com/artifact/org.virtuslab/beholder_2.11).
@@ -47,7 +47,8 @@ and junction table joined them by ids.
 Defining view
 -------------
 
-Usually for data in view does not came form single table so we have to create view that is materialisation of some query. Beholder provieds such utility. We can create Slick's table that operate on view (it is read only).
+Usually for data in view does not came form single table so we have to create view that is materialisation of some query.
+Beholder provides such utility. We can create Slick's table that operate on view (it is read only).
 
 ```scala
 case class UserMachineView(email: String, system: String, cores: Int)
@@ -76,7 +77,6 @@ UsersMachineView.viewDDL.create
 Defining filter
 ---------------
 We create a filter by specify table query (view or normal table) and mapping for field
-
 
 ```scala
 val UsersMachineFilter = new FiltersGenerator[UserMachineView].create(view,

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,7 @@ name := "beholder"
 
 version := "0.2.3-SNAPSHOT"
 
-scalaVersion := "2.11.4"
-
-crossScalaVersions := Seq("2.10.4", scalaVersion.value)
+scalaVersion := "2.11.5"
 
 resolvers += Resolver.typesafeRepo("releases")
 
@@ -16,11 +14,11 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "2.1.0",
-  "com.typesafe.play" %% "play-slick" % "0.8.0",
-  "org.virtuslab" %% "unicorn" % "0.6.1",
-  "org.scalatest" %% "scalatest" % "2.2.2" % "test",
+  "com.typesafe.play" %% "play-slick" % "0.8.1",
+  "org.virtuslab" %% "unicorn" % "0.6.2",
+  "org.scalatest" %% "scalatest" % "2.2.3" % "test",
   "com.typesafe.play" %% "play-test" % "2.3.7" % "test",
-  "com.h2database" % "h2" % "1.4.181" % "test"
+  "com.h2database" % "h2" % "1.4.184" % "test"
 )
 
 parallelExecution in Test := false
@@ -31,7 +29,8 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-unchecked",
   "-feature",
-  "-Xlint"
+  "-Xlint",
+  "-Xfatal-warnings"
 )
 
 com.typesafe.sbt.SbtScalariform.scalariformSettings
@@ -67,3 +66,16 @@ pomExtra := <url>https://github.com/VirtusLab/beholder</url>
   </developers>
 
 xerial.sbt.Sonatype.sonatypeSettings
+
+// Scoverage setup
+
+ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 48
+
+ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true
+
+ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := Seq(
+  "org.virtuslab.beholder.utils.generators.*",
+  // only BaseView5 is tested, all are generated, so there is no need to check them all
+  "org.virtuslab.beholder.views.FilterableViews.*",
+  "org.virtuslab.beholder.views.FilterableViewsGenerateCode.BaseView[^5].*"
+).mkString(";")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,7 @@ addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
+
+resolvers += Classpaths.sbtPluginReleases
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")

--- a/src/main/scala/org/virtuslab/beholder/filters/BaseFilter.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/BaseFilter.scala
@@ -1,10 +1,11 @@
 package org.virtuslab.beholder.filters
 
 import org.virtuslab.beholder.views.BaseView
-import play.api.libs.json.Json
-import scala.slick.lifted.Ordered
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+import play.api.libs.json.Json
+
 import scala.slick.ast.TypedCollectionTypeConstructor
+import scala.slick.lifted.Ordered
 
 case class Order(column: String, asc: Boolean)
 
@@ -19,7 +20,6 @@ object Order {
  * @param take how many elements to take
  * @param skip how many elements to skip before taking
  * @param orderBy field by which ordering is done
- * @param data
  */
 case class FilterDefinition(
   take: Option[Int],
@@ -56,16 +56,13 @@ abstract class BaseFilter[Id, Entity, FilterTable <: BaseView[Id, Entity], Field
     assert(data.size == filterFields.size, "Wrong numbers of columns")
 
     filterFields.zip(data).zip(tableColumns(table)).flatMap {
-      case ((columnDef, data), column) =>
-        data.map(columnDef.doFilter(column))
+      case ((columnDef, dataElem), column) =>
+        dataElem.map(columnDef.doFilter(column))
     }
   }
 
   /**
    * applies filter data into query where clauses
-   * @param data
-   * @param table
-   * @return
    */
   protected def filters(data: Seq[Option[Any]])(table: FilterTable): Column[Option[Boolean]] = {
     columnsFilters(table, data).foldLeft(LiteralColumn(Some(true)): Column[Option[Boolean]]) {
@@ -101,9 +98,6 @@ abstract class BaseFilter[Id, Entity, FilterTable <: BaseView[Id, Entity], Field
 
   /**
    * filter and sort all entities with given data
-   * @param data
-   * @param session
-   * @return
    */
   final override def filter(data: FilterDefinition)(implicit session: Session): Seq[Entity] =
     takeAndSkip(data, createFilter(data))

--- a/src/main/scala/org/virtuslab/beholder/filters/FilterFactoryMethods.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/FilterFactoryMethods.scala
@@ -1,55 +1,12 @@
 package org.virtuslab.beholder.filters
 
-import scala.slick.ast.TypedType
-import scala.slick.lifted.TableQuery
 import org.virtuslab.beholder.views.FilterableViews._
 import org.virtuslab.unicorn.LongUnicornPlay
 
-private[beholder] object FormFiltersGenerator extends App {
-  final def generateCode = {
-    (3 to 18).map {
-      implicit nr =>
-        import org.virtuslab.beholder.utils.CodeGenerationUtils._
-
-        val fieldFilters = fill(nr => s"c${nr}Mapping: FieldType[A$nr, B$nr]", ",\n")
-        val mappings = fill(n => s"c${n}Mapping")
-        val columnsNames = fill("table.c" + _)
-
-        s"""
-          |def create[$aTypesWithTypedType,
-          |           $bTypes,
-          |           T <: BaseView$nr[Entity,
-          |             $aTypes]](table: TableQuery[T],
-          |                       $fieldFilters):
-          |             FilterAPI[Entity, Formatter] = {
-          |
-          |    new BaseFilter[A1, Entity, T, FieldType[_, _], Formatter](table) {
-          |
-          |      override val formatter: Formatter = createFormatter(this)
-          |
-          |      override protected def emptyFilterDataInner: Seq[Option[Any]] = Seq.fill($nr)(None)
-          |
-          |      override def filterFields: Seq[FieldType[_, _]] =
-          |       Seq[FieldType[_, _]]($mappings)
-          |
-          |      override protected def tableColumns(table: T): Seq[LongUnicornPlay.driver.simple.Column[_]] = Seq(
-          |       $columnsNames
-          |      )
-          |    }
-          |  }
-        """.stripMargin
-
-    }
-  }
-
-  println(generateCode.mkString("\n"))
-}
-
 import scala.language.higherKinds
+import scala.slick.ast.TypedType
+import scala.slick.lifted.TableQuery
 
-/**
- * Author: Krzysztof Romanowski
- */
 abstract class FilterFactoryMethods[Entity, FieldType[_, _] <: MappedFilterField[_, _], Formatter] {
 
   def createFormatter(table: BaseFilter[_, _, _, FieldType[_, _], Formatter]): Formatter

--- a/src/main/scala/org/virtuslab/beholder/filters/FilterField.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/FilterField.scala
@@ -12,9 +12,6 @@ trait FilterField {
 
   /**
    * filter on column - apply filter form data into sql - default returns true
-   * @param column
-   * @param value
-   * @return
    */
   def doFilter(column: Column[_])(value: Any): Column[Option[Boolean]]
 }

--- a/src/main/scala/org/virtuslab/beholder/filters/forms/FormFilterField.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/forms/FormFilterField.scala
@@ -1,14 +1,14 @@
 package org.virtuslab.beholder.filters.forms
 
-import scala.slick.ast.{ BaseTypedType, TypedType }
-import play.api.data.{ FormError, Mapping }
-import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 import org.virtuslab.beholder.filters.{ FilterRange, MappedFilterField }
-import play.api.data.validation.Constraint
-import play.api.data.format.Formatter
-import play.api.data.Forms._
 import org.virtuslab.beholder.utils.ILikeExtension._
-import scala.Some
+import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+import play.api.data.Forms._
+import play.api.data.format.Formatter
+import play.api.data.validation.Constraint
+import play.api.data.{ FormError, Mapping }
+
+import scala.slick.ast.{ BaseTypedType, TypedType }
 
 abstract class FormFilterField[A: TypedType, B](mapping: Mapping[B]) extends MappedFilterField[A, B] {
 
@@ -18,6 +18,7 @@ abstract class FormFilterField[A: TypedType, B](mapping: Mapping[B]) extends Map
 }
 
 object FromFilterFields {
+
   private def ignoreMapping[T] = new Mapping[T] {
     val key = ""
     val mappings: Seq[Mapping[_]] = Nil
@@ -37,13 +38,12 @@ object FromFilterFields {
   private def rangeMapping[T: Formatter] = mapping(
     "from" -> optional(of[T]),
     "to" -> optional(of[T])
-  )(FilterRange.apply _)(FilterRange.unapply _)
+  )(FilterRange.apply)(FilterRange.unapply)
 
   //API
 
   /**
    * search in text (ilike)
-   * @return
    */
   object inIntField extends FormFilterField[Int, Int](number) {
     override def filterOnColumn(column: Column[Int])(data: Int): Column[Option[Boolean]] = column === data
@@ -51,7 +51,6 @@ object FromFilterFields {
 
   /**
    * simple check boolean
-   * @return
    */
   object inBoolean extends FormFilterField[Boolean, Boolean](boolean) {
     override def filterOnColumn(column: Column[Boolean])(data: Boolean): Column[Option[Boolean]] = column === data
@@ -74,7 +73,6 @@ object FromFilterFields {
   /**
    * check enum value
    * @tparam T - enum class (eg. Colors.type)
-   * @return
    */
   def inEnum[T <: Enumeration](implicit tm: BaseTypedType[T#Value], formatter: Formatter[T#Value]): FormFilterField[T#Value, T#Value] =
     inField[T#Value]
@@ -98,10 +96,6 @@ object FromFilterFields {
 
   /**
    * Search in range (form contain from and to).
-   * @param tm
-   * @param f
-   * @tparam T
-   * @return
    */
   def inOptionRange[T](implicit tm: BaseTypedType[T], f: Formatter[T]): FormFilterField[Option[T], FilterRange[T]] =
     new FormFilterField[Option[T], FilterRange[T]](rangeMapping[T]) {
@@ -115,8 +109,6 @@ object FromFilterFields {
 
   /**
    * Ignores given field in filter.
-   * @tparam T
-   * @return
    */
   def ignore[T: TypedType]: FormFilterField[T, T] = new FormFilterField[T, T](ignoreMapping[T]) {
     override def filterOnColumn(column: Column[T])(value: T): Column[Option[Boolean]] = LiteralColumn(Some(true))

--- a/src/main/scala/org/virtuslab/beholder/filters/forms/FormFormatter.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/forms/FormFormatter.scala
@@ -1,9 +1,9 @@
 package org.virtuslab.beholder.filters.forms
 
-import play.api.data.{ FormError, Form, Mapping }
-import org.virtuslab.beholder.filters.{ Order, FilterDefinition }
+import org.virtuslab.beholder.filters.{ FilterDefinition, Order }
 import play.api.data.Forms._
 import play.api.data.format.Formatter
+import play.api.data.{ Form, FormError, Mapping }
 
 case class FormFormatter(filterFields: Seq[FormFilterField[_, _]], columnsNames: Seq[String]) {
 
@@ -36,8 +36,8 @@ case class FormFormatter(filterFields: Seq[FormFilterField[_, _]], columnsNames:
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Order] = {
       data.get(columnKey(key)).fold[Either[Seq[FormError], Order]](Left(Seq(FormError(key, "no field to order by")))) { value =>
         data.get(ascKey(key)) match {
-          case Some("true") => Right(Order(value, true))
-          case Some("false") => Right(Order(value, false))
+          case Some("true") => Right(Order(value, asc = true))
+          case Some("false") => Right(Order(value, asc = false))
           case _ => Left(Seq(FormError(ascKey(columnKey(key)), "Asc field not set!")))
         }
       }
@@ -57,13 +57,11 @@ case class FormFormatter(filterFields: Seq[FormFilterField[_, _]], columnsNames:
 
   /**
    * from mapping for this filter
-   * @return
    */
   protected def filterMapping: Mapping[FilterDefinition] = baseFilterEntityMapping
 
   /**
    * form for this filter
-   * @return
    */
   final def filterForm = Form(filterMapping)
 }

--- a/src/main/scala/org/virtuslab/beholder/filters/json/FilterController.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/FilterController.scala
@@ -1,13 +1,10 @@
 package org.virtuslab.beholder.filters.json
 
-import org.virtuslab.beholder.filters.{ FilterDefinition, FilterAPI }
-import play.api.mvc._
+import org.virtuslab.beholder.filters.{ FilterAPI, FilterDefinition }
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple.Session
 import play.api.libs.json.JsValue
+import play.api.mvc._
 
-/**
- * Author: Krzysztof Romanowski
- */
 abstract class FilterController[Entity <: Product](filter: FilterAPI[Entity, JsonFormatter[Entity]]) extends Controller {
 
   protected def inSession(body: Request[AnyContent] => Session => Option[JsValue]): EssentialAction

--- a/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilterField.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilterField.scala
@@ -1,18 +1,15 @@
 package org.virtuslab.beholder.filters.json
 
+import org.joda.time.DateTime
 import org.virtuslab.beholder.filters._
 import org.virtuslab.beholder.utils.ILikeExtension._
+import org.virtuslab.unicorn.LongUnicornPlay.CustomTypeMappers._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 import play.api.libs.functional.syntax._
-import org.virtuslab.unicorn.LongUnicornPlay.CustomTypeMappers._
 import play.api.libs.json._
 
 import scala.slick.ast.{ BaseTypedType, TypedType }
-import org.joda.time.DateTime
 
-/**
- * Author: Krzysztof Romanowski
- */
 abstract class JsonFilterField[A: TypedType, B] extends MappedFilterField[A, B] {
   def fieldDefinition: JsValue
 
@@ -40,7 +37,6 @@ object JsonFilterFields {
 
   /**
    * search in text (ilike)
-   * @return
    */
   object inIntField extends ImplicitlyJsonFilterFiled[Int, Int]("Int") {
     override protected def filterOnColumn(column: Column[Int])(data: Int): Column[Option[Boolean]] = column === data
@@ -52,7 +48,6 @@ object JsonFilterFields {
 
   /**
    * simple check boolean
-   * @return
    */
   object inBoolean extends ImplicitlyJsonFilterFiled[Boolean, Boolean]("Boolean") {
     override def filterOnColumn(column: Column[Boolean])(data: Boolean): Column[Option[Boolean]] = column === data
@@ -79,7 +74,6 @@ object JsonFilterFields {
   /**
    * check enum value
    * @tparam T - enum class (eg. Colors.type)
-   * @return
    */
   def inEnum[T <: Enumeration](enum: T)(implicit tm: BaseTypedType[T#Value], formatter: Format[T#Value]): JsonFilterField[T#Value, T#Value] = {
     new JsonFilterField[T#Value, T#Value] {
@@ -150,8 +144,6 @@ object JsonFilterFields {
 
   /**
    * Ignores given field in filter.
-   * @tparam T
-   * @return
    */
   def ignore[T: TypedType: Writes]: JsonFilterField[T, T] = new JsonFilterField[T, T] {
 

--- a/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilters.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilters.scala
@@ -2,9 +2,6 @@ package org.virtuslab.beholder.filters.json
 
 import org.virtuslab.beholder.filters.{ BaseFilter, FilterFactoryMethods }
 
-/**
- * Author: Krzysztof Romanowski
- */
 class JsonFilters[Entity <: Product] extends FilterFactoryMethods[Entity, JsonFilterField, JsonFormatter[Entity]] {
   override def createFormatter(table: BaseFilter[_, _, _, JsonFilterField[_, _], JsonFormatter[Entity]]) =
     new JsonFormatter[Entity](table.filterFields, table.columnsNames)

--- a/src/main/scala/org/virtuslab/beholder/filters/json/JsonFormatter.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/JsonFormatter.scala
@@ -1,13 +1,11 @@
 package org.virtuslab.beholder.filters.json
 
-import org.virtuslab.beholder.filters.{ FilterResult, FilterDefinition, Order }
+import org.virtuslab.beholder.filters.{ FilterDefinition, FilterResult, Order }
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{ JsObject, _ }
 
-/**
- * Author: Krzysztof Romanowski
- */
 class JsonFormatter[Entity <: Product](filterFields: Seq[JsonFilterField[_, _]], columnsNames: Seq[String]) {
+
   def jsonDefinition: JsValue = {
     JsObject(
       columnsNames.zip(filterFields.map(_.fieldDefinition))
@@ -33,7 +31,7 @@ class JsonFormatter[Entity <: Product](filterFields: Seq[JsonFilterField[_, _]],
     override def reads(json: JsValue): JsResult[Seq[Option[Any]]] = json match {
       case jsObject: JsObject =>
         jsObject.keys -- columnsNames.toSet match {
-          case badFields if !badFields.isEmpty =>
+          case badFields if badFields.nonEmpty =>
             JsError((JsPath(Nil), ValidationError("No such fields in filter: " + badFields)))
           case _ =>
             val fieldResults = columnsNames.map(jsObject.value.get).zip(filterFields).map {

--- a/src/main/scala/org/virtuslab/beholder/utils/ILikeExtension.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/ILikeExtension.scala
@@ -11,6 +11,7 @@ import scala.slick.lifted._
  * to work import iLikeExtension from its body in scope
  */
 object ILikeExtension {
+
   val ILIKE = new SqlOperator("ilike")
 
   /**

--- a/src/main/scala/org/virtuslab/beholder/utils/generators/CodeGenerationUtils.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/generators/CodeGenerationUtils.scala
@@ -1,4 +1,4 @@
-package org.virtuslab.beholder.utils
+package org.virtuslab.beholder.utils.generators
 
 /**
  * Utils for code generation - not used in production code
@@ -7,38 +7,26 @@ private[beholder] object CodeGenerationUtils {
 
   /**
    * create sequence of string with given function Int => String separated by separator for given numbers (starts with 1)
-   * @param baseText
-   * @param sep
-   * @param to
-   * @return
    */
   def fill(baseText: Int => String, sep: String = ", ")(implicit to: Int) = (1 to to).map(baseText).mkString(sep)
 
   /**
    * create A1, A2, etc
-   * @param nr
-   * @return
    */
   def aTypes(implicit nr: Int) = fill("A" + _)(nr)
 
   /**
    * create B1, B2, etc
-   * @param nr
-   * @return
    */
   def bTypes(implicit nr: Int) = fill("B" + _)(nr)
 
   /**
    * create A1:TypeMapper, A2:TypeMapper, etc
-   * @param nr
-   * @return
    */
   def aTypesWithTypedType(implicit nr: Int) = fill(nr => s"A$nr:TypedType")(nr)
 
   /**
    * create B1:Formatter, B2:Formatter, etc
-   * @param nr
-   * @return
    */
   def bTypesWithFormatter(implicit nr: Int) = fill(nr => s"B$nr:Formatter")(nr)
 

--- a/src/main/scala/org/virtuslab/beholder/utils/generators/FilterableViewsGenerator.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/generators/FilterableViewsGenerator.scala
@@ -1,15 +1,13 @@
-package org.virtuslab.beholder.views
+package org.virtuslab.beholder.utils.generators
 
-import org.virtuslab.beholder.utils.CodeGenerationUtils._
+import org.virtuslab.beholder.utils.generators.CodeGenerationUtils._
 
-private object FilterableViewsGenerator extends App {
+private[beholder] object FilterableViewsGenerator extends App {
 
-  //for code generation
   println(generate.mkString("\n\n"))
 
   /**
    * generate code for [db.FilterableViewsGenerateCode]
-   * @return
    */
   def generate = (3 to 18).map(generateSingle)
 

--- a/src/main/scala/org/virtuslab/beholder/utils/generators/FormFiltersGenerator.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/generators/FormFiltersGenerator.scala
@@ -1,0 +1,43 @@
+package org.virtuslab.beholder.utils.generators
+
+import org.virtuslab.beholder.utils.generators.CodeGenerationUtils._
+
+private[beholder] object FormFiltersGenerator extends App {
+
+  final def generateCode = {
+    (3 to 18).map {
+      implicit nr =>
+
+        val fieldFilters = fill(nr => s"c${nr}Mapping: FieldType[A$nr, B$nr]", ",\n")
+        val mappings = fill(n => s"c${n}Mapping")
+        val columnsNames = fill("table.c" + _)
+
+        s"""
+          |def create[$aTypesWithTypedType,
+          |           $bTypes,
+          |           T <: BaseView$nr[Entity,
+          |             $aTypes]](table: TableQuery[T],
+          |                       $fieldFilters):
+          |             FilterAPI[Entity, Formatter] = {
+          |
+          |    new BaseFilter[A1, Entity, T, FieldType[_, _], Formatter](table) {
+          |
+          |      override val formatter: Formatter = createFormatter(this)
+          |
+          |      override protected def emptyFilterDataInner: Seq[Option[Any]] = Seq.fill($nr)(None)
+          |
+          |      override def filterFields: Seq[FieldType[_, _]] =
+          |       Seq[FieldType[_, _]]($mappings)
+          |
+          |      override protected def tableColumns(table: T): Seq[LongUnicornPlay.driver.simple.Column[_]] = Seq(
+          |       $columnsNames
+          |      )
+          |    }
+          |  }
+        """.stripMargin
+
+    }
+  }
+
+  println(generateCode.mkString("\n"))
+}

--- a/src/main/scala/org/virtuslab/beholder/views/BaseView.scala
+++ b/src/main/scala/org/virtuslab/beholder/views/BaseView.scala
@@ -3,6 +3,7 @@ package org.virtuslab.beholder.views
 import org.virtuslab.unicorn.LongUnicornPlay._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.DDL
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.language.existentials
 import scala.slick.lifted.{ TableQuery, Tag }
 
@@ -24,21 +25,17 @@ abstract class BaseView[Id, Entity](tag: Tag, val viewName: String) extends Base
 
   /**
    * find column by name
-   * @param name
-   * @return
    */
   def columnByName[A](name: String): Column[_] =
     columnsMap(name).apply(this)
 
   /**
    * column that is tread as view 'id' - it is use eg. for default sort
-   * @return
    */
   def id: Column[Id]
 
   /**
    * query that build this view
-   * @return
    */
   def query: Query[_, Entity, Seq]
 
@@ -67,8 +64,6 @@ object BaseView {
 
     /**
      * util to print select query sql
-     * @param query
-     * @return
      */
     private def selectStatements(query: Query[_, _, Seq]): String = query.selectStatement
 

--- a/src/main/scala/org/virtuslab/beholder/views/FilterableViews.scala
+++ b/src/main/scala/org/virtuslab/beholder/views/FilterableViews.scala
@@ -1,14 +1,12 @@
 package org.virtuslab.beholder.views
 
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.reflect.ClassTag
 import scala.slick.ast.TypedType
-import scala.slick.lifted.{ TableQuery, Tag, Column }
+import scala.slick.lifted.{ Column, TableQuery, Tag }
 
-/**
- * generates code for file FilterableViewsGeneratedCode
- */
-object FilterableViews extends App with FilterableViewsGenerateCode {
+object FilterableViews extends FilterableViewsGenerateCode {
 
   /**
    * create view with 2 fields
@@ -18,7 +16,7 @@ object FilterableViews extends App with FilterableViewsGenerateCode {
    * @param baseQuery query for create view - it should returns E
    * @param mappings map E to columns that suits apply function
    * @tparam T entity
-   * @tparam E value returns form query (in sence of columns and tables not entities) - usually tuple with tables
+   * @tparam E value returns form query (in sense of columns and tables not entities) - usually tuple with tables
    * @tparam A first field
    * @tparam B sec field
    * @return table for this view

--- a/src/main/scala/org/virtuslab/beholder/views/FilterableViewsGenerateCode.scala
+++ b/src/main/scala/org/virtuslab/beholder/views/FilterableViewsGenerateCode.scala
@@ -1,14 +1,16 @@
 package org.virtuslab.beholder.views
 
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.reflect.ClassTag
 import scala.slick.ast.TypedType
-import scala.slick.lifted.{ TableQuery, Tag, Column }
+import scala.slick.lifted.{ Column, TableQuery, Tag }
 
 /**
  * Generated code for filterable views.
  */
-trait FilterableViewsGenerateCode {
+private[beholder] trait FilterableViewsGenerateCode {
+
   def createView[T: ClassTag, E, A1: TypedType, A2: TypedType, A3: TypedType](
     name: String,
     apply: (A1, A2, A3) => T,

--- a/src/test/scala/org/virtuslab/beholder/BaseTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/BaseTest.scala
@@ -1,15 +1,17 @@
 package org.virtuslab.beholder
 
-import org.scalatest._
+import java.sql.Date
+
+import org.joda.time.DateTime
+import org.scalatest.{ BeforeAndAfterEach, FlatSpecLike, Matchers }
 import org.virtuslab.beholder.model._
 import org.virtuslab.beholder.repositories._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 import play.api.Play
 import play.api.db.slick.DB
 import play.api.test.FakeApplication
+
 import scala.slick.lifted.TableQuery
-import org.joda.time.DateTime
-import java.sql.Date
 
 trait BaseTest extends FlatSpecLike with Matchers
 
@@ -24,7 +26,6 @@ trait ModelIncluded {
 
   final def rollbackWithModel[A](func: Session => A): A = rollback {
     implicit session: Session =>
-      User
       UsersRepository.create
       MachineRepository.create
       userMachineQuery.ddl.create
@@ -36,8 +37,7 @@ trait ModelIncluded {
     val users = Seq(
       User(None, "a@a.pl", "Ala", "maKota"),
       User(None, "o@a.pl", "Ola", "maPsa")
-    ).
-      map(user => user.copy(id = Some(UsersRepository.save(user))))
+    ).map(user => user.copy(id = Some(UsersRepository.save(user))))
 
     val machines = Seq(
       Machine(None, "a@a.pl", "Ubuntu", 4, new Date(DateTime.now().minusHours(24).getMillis), Some(1)),

--- a/src/test/scala/org/virtuslab/beholder/FormFiltersTests.scala
+++ b/src/test/scala/org/virtuslab/beholder/FormFiltersTests.scala
@@ -2,16 +2,13 @@ package org.virtuslab.beholder
 
 import java.sql.Date
 
-import org.virtuslab.beholder.filters.{ FilterAPI, FilterDefinition }
 import org.virtuslab.beholder.filters.forms.FromFilterFields._
 import org.virtuslab.beholder.filters.forms.{ FormFilters, FormFormatter, FromFilterFields }
+import org.virtuslab.beholder.filters.{ FilterAPI, FilterDefinition }
 import org.virtuslab.beholder.suites.{ BaseSuite, FiltersTestSuite, RangeFiltersSuite }
 import org.virtuslab.unicorn.LongUnicornPlay._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 
-/**
- * Author: Krzysztof Romanowski
- */
 trait FormFiltersTestsBase {
   self: AppTest with BaseSuite[FormFormatter] =>
 

--- a/src/test/scala/org/virtuslab/beholder/JsonFiltersTests.scala
+++ b/src/test/scala/org/virtuslab/beholder/JsonFiltersTests.scala
@@ -2,9 +2,9 @@ package org.virtuslab.beholder
 
 import java.sql.Date
 
-import org.virtuslab.beholder.filters.{ FilterAPI, FilterDefinition }
 import org.virtuslab.beholder.filters.json.JsonFilterFields.{ inIntField, inOptionRange, inRange, _ }
 import org.virtuslab.beholder.filters.json.{ JsonFilterFields, JsonFilters, JsonFormatter }
+import org.virtuslab.beholder.filters.{ FilterAPI, FilterDefinition }
 import org.virtuslab.beholder.suites.{ BaseSuite, FiltersTestSuite, RangeFiltersSuite }
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 import play.api.libs.json.JsObject

--- a/src/test/scala/org/virtuslab/beholder/UserMachinesView.scala
+++ b/src/test/scala/org/virtuslab/beholder/UserMachinesView.scala
@@ -1,10 +1,11 @@
 package org.virtuslab.beholder
 
+import java.sql.Date
+
 import org.virtuslab.beholder.model.{ Machines, Users }
 import org.virtuslab.beholder.views.FilterableViews
-import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 import org.virtuslab.unicorn.LongUnicornPlay._
-import java.sql.Date
+import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 
 case class UserMachineViewRow(
   email: String,

--- a/src/test/scala/org/virtuslab/beholder/ViewsTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/ViewsTest.scala
@@ -16,4 +16,12 @@ class ViewsTest extends AppTest with UserMachinesView {
       all.size shouldEqual 3
   }
 
+  "view" should "be creatable" in rollbackWithModel {
+    implicit session =>
+      val view = createUsersMachineView
+      view.viewDDL.drop
+      view.viewDDL.create
+      view.viewDDL.drop
+  }
+
 }

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFormatterTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFormatterTest.scala
@@ -1,22 +1,19 @@
 package org.virtuslab.beholder.json
 
-import org.virtuslab.beholder._
-import org.virtuslab.beholder.filters.json.{ JsonFilterFields, JsonFilters }
-import org.virtuslab.beholder.filters.json.JsonFilterFields._
 import java.sql.Date
-import org.virtuslab.beholder.UserMachineViewRow
-import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
-import play.api.libs.json.{ JsString, JsObject }
-import org.virtuslab.beholder.filters.FilterDefinition
 
-/**
- * Author: Krzysztof Romanowski
- */
+import org.virtuslab.beholder.filters.FilterDefinition
+import org.virtuslab.beholder.filters.json.JsonFilterFields._
+import org.virtuslab.beholder.filters.json.{ JsonFilterFields, JsonFilters }
+import org.virtuslab.beholder.{ UserMachineViewRow, _ }
+import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+import play.api.libs.json.{ JsObject, JsString }
+
 class JsonFormatterTest extends AppTest with UserMachinesView with ModelIncluded {
 
   behavior of "JsonFormatter"
 
-  it should "parse data corrently" in rollbackWithModel {
+  it should "parse data correctly" in rollbackWithModel {
     implicit session =>
       lazy val view = createUsersMachineView
 
@@ -31,8 +28,8 @@ class JsonFormatterTest extends AppTest with UserMachinesView with ModelIncluded
 
       val req = JsObject(Seq("data" -> JsObject(Seq("email" -> JsString("ala")))))
 
-      val data = FilterDefinition(None, None, None, Seq(Some("ala")))
+      val data = FilterDefinition(None, None, None, Seq(Some("ala"), None, None, None, None))
 
-      data should equal(data)
+      filter.formatter.filterDefinition(req) shouldEqual Some(data)
   }
 }

--- a/src/test/scala/org/virtuslab/beholder/model/Machine.scala
+++ b/src/test/scala/org/virtuslab/beholder/model/Machine.scala
@@ -1,8 +1,9 @@
 package org.virtuslab.beholder.model
 
+import java.sql.Date
+
 import org.virtuslab.unicorn.LongUnicornPlay._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
-import java.sql.Date
 
 /** Id class for type-safe joins and queries. */
 case class MachineId(id: Long) extends AnyVal with BaseId

--- a/src/test/scala/org/virtuslab/beholder/model/User.scala
+++ b/src/test/scala/org/virtuslab/beholder/model/User.scala
@@ -2,6 +2,7 @@ package org.virtuslab.beholder.model
 
 import org.virtuslab.unicorn.LongUnicornPlay._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.slick.lifted.Tag
 
 /** Id class for type-safe joins and queries. */

--- a/src/test/scala/org/virtuslab/beholder/model/UserMachines.scala
+++ b/src/test/scala/org/virtuslab/beholder/model/UserMachines.scala
@@ -1,6 +1,7 @@
 package org.virtuslab.beholder.model
 
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.slick.lifted.{ TableQuery, Tag }
 
 class UserMachines(tag: Tag) extends Table[(UserId, MachineId)](tag, "users_machines") {

--- a/src/test/scala/org/virtuslab/beholder/repositories/MachineRepository.scala
+++ b/src/test/scala/org/virtuslab/beholder/repositories/MachineRepository.scala
@@ -1,8 +1,9 @@
 package org.virtuslab.beholder.repositories
 
-import org.virtuslab.beholder.model.{ Machines, Machine, MachineId }
+import org.virtuslab.beholder.model.{ Machine, MachineId, Machines }
 import org.virtuslab.unicorn.LongUnicornPlay._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.slick.lifted.TableQuery
 
 /**

--- a/src/test/scala/org/virtuslab/beholder/repositories/UsersRepository.scala
+++ b/src/test/scala/org/virtuslab/beholder/repositories/UsersRepository.scala
@@ -1,9 +1,9 @@
 package org.virtuslab.beholder.repositories
 
-import org.virtuslab.beholder.model.User
-import org.virtuslab.beholder.model._
+import org.virtuslab.beholder.model.{ User, _ }
 import org.virtuslab.unicorn.LongUnicornPlay._
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
+
 import scala.slick.lifted.TableQuery
 
 class UsersRepository extends BaseIdRepository[UserId, User, Users](TableQuery[Users])

--- a/src/test/scala/org/virtuslab/beholder/suites/BaseSuite.scala
+++ b/src/test/scala/org/virtuslab/beholder/suites/BaseSuite.scala
@@ -1,12 +1,9 @@
 package org.virtuslab.beholder.suites
 
-import org.virtuslab.beholder.filters.{ FilterDefinition, FilterAPI }
-import org.virtuslab.beholder.{ AppTest, UserMachinesView, UserMachineViewRow }
+import org.virtuslab.beholder.filters.{ FilterAPI, FilterDefinition }
+import org.virtuslab.beholder.{ AppTest, UserMachineViewRow, UserMachinesView }
 import org.virtuslab.unicorn.LongUnicornPlay.driver.simple._
 
-/**
- * Author: Krzysztof Romanowski
- */
 trait BaseSuite[Formatter] extends UserMachinesView {
   self: AppTest =>
   def createFilter(data: BaseFilterData): FilterAPI[UserMachineViewRow, Formatter]
@@ -22,7 +19,6 @@ trait BaseSuite[Formatter] extends UserMachinesView {
 
     lazy val filter = createFilter(this)
 
-    /**/
     lazy val baseFilter = filter.emptyFilterData
     lazy val baseFilterData = baseFilter.data
 

--- a/src/test/scala/org/virtuslab/beholder/suites/FiltersTestSuite.scala
+++ b/src/test/scala/org/virtuslab/beholder/suites/FiltersTestSuite.scala
@@ -1,9 +1,10 @@
 package org.virtuslab.beholder.suites
 
-import org.virtuslab.beholder.filters._
-import org.joda.time.DateTime
 import java.sql.Date
+
+import org.joda.time.DateTime
 import org.virtuslab.beholder.AppTest
+import org.virtuslab.beholder.filters._
 
 trait FiltersTestSuite[Formatter] extends BaseSuite[Formatter] {
   self: AppTest =>
@@ -99,7 +100,7 @@ trait FiltersTestSuite[Formatter] extends BaseSuite[Formatter] {
       val filterData = filter.filterWithTotalEntitiesNumber(baseFilter.copy(orderBy = Some(Order("cores", asc = false)), skip = Some(1)))
       val fromDbOrderedByCoresDesc = allFromDb.sortBy(view => (-view.cores, view.email))
 
-      filterData.content should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1);
+      filterData.content should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
 
       filterData.total shouldEqual allFromDb.size
 


### PR DESCRIPTION
Currently, with all generators and BaseView[^5] excluded coverage is 48%.

Dependencies updated; Scala 2.11.4 -> 2.11.5; as support for 2.10 was dropped
I removed it from build scripts.

Imports optimized, empty comments and author comments removed.

All generators (not generated code) moved to `utils.generators` package to
enable easy exclusion from coverage.