### PR TITLE
Improvements to build and docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.MF eol=lf
+*.md eol=lf
 *.sbt eol=lf
 *.scala eol=lf
 *.yml eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ jdk:
   - openjdk7
   - oraclejdk8
 
-script: sbt -no-colors ++$TRAVIS_SCALA_VERSION clean coverage test
+sbt_args: -no-colors
+script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test doc
+after_success: sbt coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,5 +28,8 @@ Minimum coverage is set to *48%* (which is current coverage) so all code you add
 Releasing
 ---------
 
-Before release you must have access to Sonatype and have PGP keys for signing artifacts. 
-For make release just use `+publishSigned +releaseSonatype`. 
+Before release you must have access to Sonatype and have PGP keys for signing artifacts.
+
+To automate release process, `beholder` uses [sbt-release](https://github.com/sbt/sbt-release) plugin. To release a new version, just use `sbt release` and follow instructions. For more information, see plugin docs.
+
+**Warn** - You should *not* update version file (`version.sbt`) yourself, `sbt-release` does it for you.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 Beholder: Play-Slick library for data presentation
 ==================================================
-[![Build Status](https://travis-ci.org/VirtusLab/beholder.svg?branch=master)](https://travis-ci.org/VirtusLab/beholder)
 
-Standard part of many application are list of data that is not a effect of simple query from one table but junction and aggregation of data from many tables. Beholder provides support for such elemets.
+[![Build Status](https://travis-ci.org/VirtusLab/beholder.svg?branch=master)](https://travis-ci.org/VirtusLab/beholder)
+[![Coverage Status](https://img.shields.io/coveralls/VirtusLab/beholder.svg)](https://coveralls.io/r/VirtusLab/beholder?branch=master)
+
+Standard part of many application are list of data that is not a effect of simple query from one table but junction and aggregation of data from many tables. Beholder provides support for such elements.
 
 Features:
 * views as table
 * declaring filters for data
-* support for sorting, filtering on multiple (custom) datatypes
+* support for sorting, filtering on multiple (custom) data types
+
+Beholder is Open Source under [Apache 2.0 license](LICENSE).
+
+ScalaDoc API for [0.2.6](http://virtuslab.com/beholder-api/0.2.6).
 
 Contributors
 ------------
@@ -17,7 +23,7 @@ Authors:
 * [Mikołaj Jakubowski](https://github.com/mkljakubowski)
 * [Krzysztof Borowski](https://github.com/liosedhel)
 
-Feel free to use it, test it and to contribute!
+Feel free to use it, test it and to contribute! For some helpful tips'n'tricks, see [contribution guide](CONTRIBUTING.md).
 
 Getting beholder
 ----------------
@@ -25,10 +31,10 @@ Getting beholder
 For latest version (Scala 2.11.5 compatible) use:
 
 ```scala
-libraryDependencies += "org.virtuslab" %% "beholder" % "0.2.2"
+libraryDependencies += "org.virtuslab" %% "beholder" % "0.2.6"
 ```
 
-Or see Maven repository for [2.10](http://maven-repository.com/artifact/org.virtuslab/beholder_2.10) and [2.11](http://maven-repository.com/artifact/org.virtuslab/beholder_2.11).
+Or see [Maven repository](http://maven-repository.com/artifact/org.virtuslab/beholder_2.11).
 
 Examples
 ========

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,16 @@
+import sbtrelease.ReleasePlugin
+
 organization := "org.virtuslab"
 
 name := "beholder"
 
-version := "0.2.5"
-
 scalaVersion := "2.11.5"
 
-resolvers += Resolver.typesafeRepo("releases")
+updateOptions := updateOptions.value.withCachedResolution(true)
 
-resolvers += Resolver.sonatypeRepo("releases")
+libraryDependencies ++= Dependencies.libraries
 
-resolvers += Resolver.sonatypeRepo("snapshots")
-
-libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick" % "2.1.0",
-  "com.typesafe.play" %% "play-slick" % "0.8.1",
-  "org.virtuslab" %% "unicorn" % "0.6.2",
-  "org.scalatest" %% "scalatest" % "2.2.3" % "test",
-  "com.typesafe.play" %% "play-test" % "2.3.7" % "test",
-  "com.h2database" % "h2" % "1.4.184" % "test"
-)
+resolvers ++= Resolvers.all
 
 parallelExecution in Test := false
 
@@ -35,47 +26,8 @@ scalacOptions ++= Seq(
 
 com.typesafe.sbt.SbtScalariform.scalariformSettings
 
-pomExtra := <url>https://github.com/VirtusLab/beholder</url>
-  <licenses>
-    <license>
-      <name>Apache-style</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>https://github.com/VirtusLab/beholder.git</url>
-    <connection>scm:git:git@github.com:VirtusLab/beholder.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>VirtusLab</id>
-      <name>VirtusLab</name>
-      <url>http://www.virtuslab.com/</url>
-    </developer>
-    <developer>
-      <id>JerzyMuller</id>
-      <name>Jerzy Müller</name>
-      <url>https://github.com/Kwestor</url>
-    </developer>
-    <developer>
-      <id>KrzysztofRomanowski</id>
-      <name>Krzysztof Romanowski</name>
-      <url>https://github.com/romanowski</url>
-    </developer>
-  </developers>
+Settings.sonatype
 
-xerial.sbt.Sonatype.sonatypeSettings
+Settings.scoverage
 
-// Scoverage setup
-
-ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 48
-
-ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true
-
-ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := Seq(
-  "org.virtuslab.beholder.utils.generators.*",
-  // only BaseView5 is tested, all are generated, so there is no need to check them all
-  "org.virtuslab.beholder.views.FilterableViews.*",
-  "org.virtuslab.beholder.views.FilterableViewsGenerateCode.BaseView[^5].*"
-).mkString(";")
+Settings.release

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,0 +1,81 @@
+import com.typesafe.sbt.pgp.PgpKeys
+import sbt._
+import sbt.Keys._
+import sbt.Resolver
+import sbtrelease.ReleasePlugin
+import sbtrelease.ReleasePlugin.ReleaseKeys
+import scoverage.ScoverageSbtPlugin
+import xerial.sbt.Sonatype
+
+object Settings {
+
+  val scoverage = Seq(
+    ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 48,
+
+    ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true,
+
+    ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := Seq(
+      "org.virtuslab.beholder.utils.generators.*",
+      // only BaseView5 is tested, all are generated, so there is no need to check them all
+      "org.virtuslab.beholder.views.FilterableViews.*",
+      "org.virtuslab.beholder.views.FilterableViewsGenerateCode.BaseView[^5].*"
+    ).mkString(";")
+  )
+
+  val sonatype = Seq(
+    pomExtra := <url>https://github.com/VirtusLab/beholder</url>
+      <licenses>
+        <license>
+          <name>Apache-style</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+      <scm>
+        <url>https://github.com/VirtusLab/beholder.git</url>
+        <connection>scm:git:git@github.com:VirtusLab/beholder.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <id>VirtusLab</id>
+          <name>VirtusLab</name>
+          <url>http://www.virtuslab.com/</url>
+        </developer>
+        <developer>
+          <id>JerzyMuller</id>
+          <name>Jerzy Müller</name>
+          <url>https://github.com/Kwestor</url>
+        </developer>
+        <developer>
+          <id>KrzysztofRomanowski</id>
+          <name>Krzysztof Romanowski</name>
+          <url>https://github.com/romanowski</url>
+        </developer>
+      </developers>
+  ) ++ Sonatype.sonatypeSettings
+
+  val release = Seq(
+    ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value
+  ) ++ ReleasePlugin.releaseSettings
+
+}
+
+object Resolvers {
+  val all: Seq[MavenRepository] = Seq(
+    Resolver.typesafeRepo("releases"),
+    Resolver.sonatypeRepo("releases"),
+    Resolver.sonatypeRepo("snapshots")
+  )
+}
+
+object Dependencies {
+
+  val libraries: Seq[ModuleID] = Seq(
+    "com.typesafe.slick" %% "slick" % "2.1.0",
+    "com.typesafe.play" %% "play-slick" % "0.8.1",
+    "org.virtuslab" %% "unicorn" % "0.6.2",
+    "com.typesafe.play" %% "play-test" % "2.3.8" % "test",
+    "org.scalatest" %% "scalatest" % "2.2.3" % "test",
+    "com.h2database" % "h2" % "1.4.184" % "test"
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,22 @@
-resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 
 addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+/* ------------------ */
+/* Deploy and release */
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
+
+/* ------------- */
+/* Code coverage */
 
 resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+
+/*---------------*/

--- a/src/test/scala/org/virtuslab/beholder/suites/FiltersTestSuite.scala
+++ b/src/test/scala/org/virtuslab/beholder/suites/FiltersTestSuite.scala
@@ -70,13 +70,15 @@ trait FiltersTestSuite[Formatter] extends BaseSuite[Formatter] {
   }
 
   //h2db does not have ilike operator
-  ignore should "filter by string field" in baseFilterTest {
+  it should "filter by string field" in baseFilterTest {
     data =>
-      import data._
-      val orderByCoreDesc = doFilters(data, baseFilter.copy(data = baseFilter.data.updated(1, Some("buntu"))))
-      val fromDbOrderedByCoresDesc = allFromDb.filter(_.system.contains("buntu"))
+      pendingUntilFixed {
+        import data._
+        val orderByCoreDesc = doFilters(data, baseFilter.copy(data = baseFilter.data.updated(1, Some("buntu"))))
+        val fromDbOrderedByCoresDesc = allFromDb.filter(_.system.contains("buntu"))
 
-      orderByCoreDesc should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
+        orderByCoreDesc should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
+      }
   }
 
   it should "not crash for date option" in baseFilterTest {

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.2.6"


### PR DESCRIPTION
Coveralls added for uploading coverage statistics.

Release plugin added for reasy release process, see CONTRIBUTING.md for
more details.

Build file simplified, big chunks of config moved to `project`.

Cache resolution for sbt enabled.

Ignored test is now pending until fixed.

Minor fixes in readme.

Scaladoc uploaded to virtuslab.com/beholder-api.