### PR TITLE
Add support up to 22 columns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,10 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.0.3",
-  "com.typesafe.play" %% "play-slick" % "1.0.0",
-  "org.virtuslab" %% "unicorn" % "0.7.0",
+  "com.typesafe.play" %% "play-slick" % "1.0.1",
+  "org.virtuslab" %% "unicorn" % "0.7.1-SNAPSHOT",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-  "com.typesafe.play" %% "play-test" % "2.4.2" % "test",
+  "com.typesafe.play" %% "play-test" % "2.4.6" % "test",
   "com.h2database" % "h2" % "1.4.187" % "test"
 )
 
@@ -77,5 +77,6 @@ ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := Seq(
   "org.virtuslab.beholder.utils.generators.*",
   // only BaseView5 is tested, all are generated, so there is no need to check them all
   "org.virtuslab.beholder.views.FilterableViews.*",
-  "org.virtuslab.beholder.views.FilterableViewsGenerateCode.BaseView[^5].*"
+  "org.virtuslab.beholder.views.FilterableViewsGenerateCode.BaseView[^5].*",
+  "org.virtuslab.beholder.filters.FilterFactoryMethods.*"
 ).mkString(";")

--- a/src/main/scala/org/virtuslab/beholder/filters/FilterFactoryMethods.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/FilterFactoryMethods.scala
@@ -454,4 +454,149 @@ abstract class FilterFactoryMethods[Entity, FieldType[_, _] <: MappedFilterField
     }
   }
 
+  def create[A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15, B16, B17, B18, B19, T <: BaseView19[Entity, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19]](table: TableQuery[T],
+    c1Mapping: FieldType[A1, B1],
+    c2Mapping: FieldType[A2, B2],
+    c3Mapping: FieldType[A3, B3],
+    c4Mapping: FieldType[A4, B4],
+    c5Mapping: FieldType[A5, B5],
+    c6Mapping: FieldType[A6, B6],
+    c7Mapping: FieldType[A7, B7],
+    c8Mapping: FieldType[A8, B8],
+    c9Mapping: FieldType[A9, B9],
+    c10Mapping: FieldType[A10, B10],
+    c11Mapping: FieldType[A11, B11],
+    c12Mapping: FieldType[A12, B12],
+    c13Mapping: FieldType[A13, B13],
+    c14Mapping: FieldType[A14, B14],
+    c15Mapping: FieldType[A15, B15],
+    c16Mapping: FieldType[A16, B16],
+    c17Mapping: FieldType[A17, B17],
+    c18Mapping: FieldType[A18, B18],
+    c19Mapping: FieldType[A19, B19]): TableFilterAPI[Entity, Formatter, T] = {
+
+    new BaseFilter[A1, Entity, T, FieldType[_, _], Formatter](table) {
+      override val formatter: Formatter = createFormatter(this)
+
+      override protected def emptyFilterDataInner: Seq[Option[Any]] = Seq.fill(19)(None)
+
+      override def filterFields: Seq[FieldType[_, _]] =
+        Seq[FieldType[_, _]](c1Mapping, c2Mapping, c3Mapping, c4Mapping, c5Mapping, c6Mapping, c7Mapping, c8Mapping, c9Mapping, c10Mapping, c11Mapping, c12Mapping, c13Mapping, c14Mapping, c15Mapping, c16Mapping, c17Mapping, c18Mapping, c19Mapping)
+
+      override protected def tableColumns(table: T): Seq[LongUnicornPlay.driver.api.Rep[_]] = Seq(
+        table.c1, table.c2, table.c3, table.c4, table.c5, table.c6, table.c7, table.c8, table.c9, table.c10, table.c11, table.c12, table.c13, table.c14, table.c15, table.c16, table.c17, table.c18, table.c19
+      )
+    }
+  }
+
+  def create[A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15, B16, B17, B18, B19, B20, T <: BaseView20[Entity, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20]](table: TableQuery[T],
+    c1Mapping: FieldType[A1, B1],
+    c2Mapping: FieldType[A2, B2],
+    c3Mapping: FieldType[A3, B3],
+    c4Mapping: FieldType[A4, B4],
+    c5Mapping: FieldType[A5, B5],
+    c6Mapping: FieldType[A6, B6],
+    c7Mapping: FieldType[A7, B7],
+    c8Mapping: FieldType[A8, B8],
+    c9Mapping: FieldType[A9, B9],
+    c10Mapping: FieldType[A10, B10],
+    c11Mapping: FieldType[A11, B11],
+    c12Mapping: FieldType[A12, B12],
+    c13Mapping: FieldType[A13, B13],
+    c14Mapping: FieldType[A14, B14],
+    c15Mapping: FieldType[A15, B15],
+    c16Mapping: FieldType[A16, B16],
+    c17Mapping: FieldType[A17, B17],
+    c18Mapping: FieldType[A18, B18],
+    c19Mapping: FieldType[A19, B19],
+    c20Mapping: FieldType[A20, B20]): TableFilterAPI[Entity, Formatter, T] = {
+
+    new BaseFilter[A1, Entity, T, FieldType[_, _], Formatter](table) {
+      override val formatter: Formatter = createFormatter(this)
+
+      override protected def emptyFilterDataInner: Seq[Option[Any]] = Seq.fill(20)(None)
+
+      override def filterFields: Seq[FieldType[_, _]] =
+        Seq[FieldType[_, _]](c1Mapping, c2Mapping, c3Mapping, c4Mapping, c5Mapping, c6Mapping, c7Mapping, c8Mapping, c9Mapping, c10Mapping, c11Mapping, c12Mapping, c13Mapping, c14Mapping, c15Mapping, c16Mapping, c17Mapping, c18Mapping, c19Mapping, c20Mapping)
+
+      override protected def tableColumns(table: T): Seq[LongUnicornPlay.driver.api.Rep[_]] = Seq(
+        table.c1, table.c2, table.c3, table.c4, table.c5, table.c6, table.c7, table.c8, table.c9, table.c10, table.c11, table.c12, table.c13, table.c14, table.c15, table.c16, table.c17, table.c18, table.c19, table.c20
+      )
+    }
+  }
+
+  def create[A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, A21: TypedType, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15, B16, B17, B18, B19, B20, B21, T <: BaseView21[Entity, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21]](table: TableQuery[T],
+    c1Mapping: FieldType[A1, B1],
+    c2Mapping: FieldType[A2, B2],
+    c3Mapping: FieldType[A3, B3],
+    c4Mapping: FieldType[A4, B4],
+    c5Mapping: FieldType[A5, B5],
+    c6Mapping: FieldType[A6, B6],
+    c7Mapping: FieldType[A7, B7],
+    c8Mapping: FieldType[A8, B8],
+    c9Mapping: FieldType[A9, B9],
+    c10Mapping: FieldType[A10, B10],
+    c11Mapping: FieldType[A11, B11],
+    c12Mapping: FieldType[A12, B12],
+    c13Mapping: FieldType[A13, B13],
+    c14Mapping: FieldType[A14, B14],
+    c15Mapping: FieldType[A15, B15],
+    c16Mapping: FieldType[A16, B16],
+    c17Mapping: FieldType[A17, B17],
+    c18Mapping: FieldType[A18, B18],
+    c19Mapping: FieldType[A19, B19],
+    c20Mapping: FieldType[A20, B20],
+    c21Mapping: FieldType[A21, B21]): TableFilterAPI[Entity, Formatter, T] = {
+
+    new BaseFilter[A1, Entity, T, FieldType[_, _], Formatter](table) {
+      override val formatter: Formatter = createFormatter(this)
+
+      override protected def emptyFilterDataInner: Seq[Option[Any]] = Seq.fill(21)(None)
+
+      override def filterFields: Seq[FieldType[_, _]] =
+        Seq[FieldType[_, _]](c1Mapping, c2Mapping, c3Mapping, c4Mapping, c5Mapping, c6Mapping, c7Mapping, c8Mapping, c9Mapping, c10Mapping, c11Mapping, c12Mapping, c13Mapping, c14Mapping, c15Mapping, c16Mapping, c17Mapping, c18Mapping, c19Mapping, c20Mapping, c21Mapping)
+
+      override protected def tableColumns(table: T): Seq[LongUnicornPlay.driver.api.Rep[_]] = Seq(
+        table.c1, table.c2, table.c3, table.c4, table.c5, table.c6, table.c7, table.c8, table.c9, table.c10, table.c11, table.c12, table.c13, table.c14, table.c15, table.c16, table.c17, table.c18, table.c19, table.c20, table.c21
+      )
+    }
+  }
+
+  def create[A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, A21: TypedType, A22: TypedType, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15, B16, B17, B18, B19, B20, B21, B22, T <: BaseView22[Entity, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22]](table: TableQuery[T],
+    c1Mapping: FieldType[A1, B1],
+    c2Mapping: FieldType[A2, B2],
+    c3Mapping: FieldType[A3, B3],
+    c4Mapping: FieldType[A4, B4],
+    c5Mapping: FieldType[A5, B5],
+    c6Mapping: FieldType[A6, B6],
+    c7Mapping: FieldType[A7, B7],
+    c8Mapping: FieldType[A8, B8],
+    c9Mapping: FieldType[A9, B9],
+    c10Mapping: FieldType[A10, B10],
+    c11Mapping: FieldType[A11, B11],
+    c12Mapping: FieldType[A12, B12],
+    c13Mapping: FieldType[A13, B13],
+    c14Mapping: FieldType[A14, B14],
+    c15Mapping: FieldType[A15, B15],
+    c16Mapping: FieldType[A16, B16],
+    c17Mapping: FieldType[A17, B17],
+    c18Mapping: FieldType[A18, B18],
+    c19Mapping: FieldType[A19, B19],
+    c20Mapping: FieldType[A20, B20],
+    c21Mapping: FieldType[A21, B21],
+    c22Mapping: FieldType[A22, B22]): TableFilterAPI[Entity, Formatter, T] = {
+
+    new BaseFilter[A1, Entity, T, FieldType[_, _], Formatter](table) {
+      override val formatter: Formatter = createFormatter(this)
+
+      override protected def emptyFilterDataInner: Seq[Option[Any]] = Seq.fill(22)(None)
+
+      override def filterFields: Seq[FieldType[_, _]] =
+        Seq[FieldType[_, _]](c1Mapping, c2Mapping, c3Mapping, c4Mapping, c5Mapping, c6Mapping, c7Mapping, c8Mapping, c9Mapping, c10Mapping, c11Mapping, c12Mapping, c13Mapping, c14Mapping, c15Mapping, c16Mapping, c17Mapping, c18Mapping, c19Mapping, c20Mapping, c21Mapping, c22Mapping)
+
+      override protected def tableColumns(table: T): Seq[LongUnicornPlay.driver.api.Rep[_]] = Seq(
+        table.c1, table.c2, table.c3, table.c4, table.c5, table.c6, table.c7, table.c8, table.c9, table.c10, table.c11, table.c12, table.c13, table.c14, table.c15, table.c16, table.c17, table.c18, table.c19, table.c20, table.c21, table.c22
+      )
+    }
+  }
 }

--- a/src/main/scala/org/virtuslab/beholder/utils/generators/FilterableViewsGenerator.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/generators/FilterableViewsGenerator.scala
@@ -9,7 +9,7 @@ private[beholder] object FilterableViewsGenerator extends App {
   /**
    * generate code for [db.FilterableViewsGenerateCode]
    */
-  def generate = (2 to 18).map(generateSingle)
+  def generate = (2 to 22).map(generateSingle)
 
   /** create code for single "create view method" */
   private def generateSingle(nr: Int) = {

--- a/src/main/scala/org/virtuslab/beholder/utils/generators/FormFiltersGenerator.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/generators/FormFiltersGenerator.scala
@@ -5,7 +5,7 @@ import org.virtuslab.beholder.utils.generators.CodeGenerationUtils._
 private[beholder] object FormFiltersGenerator extends App {
 
   final def generateCode = {
-    (2 to 18).map {
+    (2 to 22).map {
       implicit nr =>
 
         val fieldFilters = fill(nr => s"c${nr}Mapping: FieldType[A$nr, B$nr]", ",\n")

--- a/src/main/scala/org/virtuslab/beholder/views/FilterableViewsGenerateCode.scala
+++ b/src/main/scala/org/virtuslab/beholder/views/FilterableViewsGenerateCode.scala
@@ -1081,4 +1081,339 @@ private[beholder] trait FilterableViewsGenerateCode {
     def * = (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18) <> (apply.tupled, unapply)
   }
 
+  def createView[T: ClassTag, E, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType](name: String,
+    apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => T,
+    unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)],
+    baseQuery: Query[E, _, Seq])(
+      mappings: E => ((String, Rep[A1]), (String, Rep[A2]), (String, Rep[A3]), (String, Rep[A4]), (String, Rep[A5]), (String, Rep[A6]), (String, Rep[A7]), (String, Rep[A8]), (String, Rep[A9]), (String, Rep[A10]), (String, Rep[A11]), (String, Rep[A12]), (String, Rep[A13]), (String, Rep[A14]), (String, Rep[A15]), (String, Rep[A16]), (String, Rep[A17]), (String, Rep[A18]), (String, Rep[A19])))(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _]): TableQuery[BaseView19[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19]] = {
+
+    var columnsNames = Seq[String]()
+
+    val preparedQuery: Query[_, T, Seq] = {
+      baseQuery.map {
+        t =>
+          mappings(t) match {
+            case ((name1, c1), (name2, c2), (name3, c3), (name4, c4), (name5, c5), (name6, c6), (name7, c7), (name8, c8), (name9, c9), (name10, c10), (name11, c11), (name12, c12), (name13, c13), (name14, c14), (name15, c15), (name16, c16), (name17, c17), (name18, c18), (name19, c19)) =>
+              columnsNames = Seq(name1, name2, name3, name4, name5, name6, name7, name8, name9, name10, name11, name12, name13, name14, name15, name16, name17, name18, name19)
+
+              implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19)
+                .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19), _]]
+
+              (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19) <> (apply.tupled, unapply)
+          }
+      }
+    }
+    TableQuery.apply(tag => new BaseView19[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](tag, name, columnsNames, apply, unapply, preparedQuery))
+
+  }
+
+  class BaseView19[T: ClassTag, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType](tag: Tag,
+      name: String,
+      val columnNames: Seq[String],
+      apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => T,
+      unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)],
+      val query: Query[_, T, Seq])(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _]) extends BaseView[A1, T](tag, name) {
+    def c1 = column[A1](columnNames(0))
+    def c2 = column[A2](columnNames(1))
+    def c3 = column[A3](columnNames(2))
+    def c4 = column[A4](columnNames(3))
+    def c5 = column[A5](columnNames(4))
+    def c6 = column[A6](columnNames(5))
+    def c7 = column[A7](columnNames(6))
+    def c8 = column[A8](columnNames(7))
+    def c9 = column[A9](columnNames(8))
+    def c10 = column[A10](columnNames(9))
+    def c11 = column[A11](columnNames(10))
+    def c12 = column[A12](columnNames(11))
+    def c13 = column[A13](columnNames(12))
+    def c14 = column[A14](columnNames(13))
+    def c15 = column[A15](columnNames(14))
+    def c16 = column[A16](columnNames(15))
+    def c17 = column[A17](columnNames(16))
+    def c18 = column[A18](columnNames(17))
+    def c19 = column[A19](columnNames(18))
+
+    override def id = c1
+
+    override protected val columns: Seq[(String, this.type => Rep[_])] = Seq(
+      columnNames(0) -> (_.c1),
+      columnNames(1) -> (_.c2),
+      columnNames(2) -> (_.c3),
+      columnNames(3) -> (_.c4),
+      columnNames(4) -> (_.c5),
+      columnNames(5) -> (_.c6),
+      columnNames(6) -> (_.c7),
+      columnNames(7) -> (_.c8),
+      columnNames(8) -> (_.c9),
+      columnNames(9) -> (_.c10),
+      columnNames(10) -> (_.c11),
+      columnNames(11) -> (_.c12),
+      columnNames(12) -> (_.c13),
+      columnNames(13) -> (_.c14),
+      columnNames(14) -> (_.c15),
+      columnNames(15) -> (_.c16),
+      columnNames(16) -> (_.c17),
+      columnNames(17) -> (_.c18),
+      columnNames(18) -> (_.c19))
+
+    implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19)
+      .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19), _]]
+
+    def * = (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19) <> (apply.tupled, unapply)
+  }
+
+  def createView[T: ClassTag, E, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType](name: String,
+    apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => T,
+    unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)],
+    baseQuery: Query[E, _, Seq])(
+      mappings: E => ((String, Rep[A1]), (String, Rep[A2]), (String, Rep[A3]), (String, Rep[A4]), (String, Rep[A5]), (String, Rep[A6]), (String, Rep[A7]), (String, Rep[A8]), (String, Rep[A9]), (String, Rep[A10]), (String, Rep[A11]), (String, Rep[A12]), (String, Rep[A13]), (String, Rep[A14]), (String, Rep[A15]), (String, Rep[A16]), (String, Rep[A17]), (String, Rep[A18]), (String, Rep[A19]), (String, Rep[A20])))(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _], s20: Shape[_, Rep[A20], A20, _]): TableQuery[BaseView20[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20]] = {
+
+    var columnsNames = Seq[String]()
+
+    val preparedQuery: Query[_, T, Seq] = {
+      baseQuery.map {
+        t =>
+          mappings(t) match {
+            case ((name1, c1), (name2, c2), (name3, c3), (name4, c4), (name5, c5), (name6, c6), (name7, c7), (name8, c8), (name9, c9), (name10, c10), (name11, c11), (name12, c12), (name13, c13), (name14, c14), (name15, c15), (name16, c16), (name17, c17), (name18, c18), (name19, c19), (name20, c20)) =>
+              columnsNames = Seq(name1, name2, name3, name4, name5, name6, name7, name8, name9, name10, name11, name12, name13, name14, name15, name16, name17, name18, name19, name20)
+
+              implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20)
+                .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19], Rep[A20]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20), _]]
+
+              (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20) <> (apply.tupled, unapply)
+          }
+      }
+    }
+    TableQuery.apply(tag => new BaseView20[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](tag, name, columnsNames, apply, unapply, preparedQuery))
+
+  }
+
+  class BaseView20[T: ClassTag, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType](tag: Tag,
+      name: String,
+      val columnNames: Seq[String],
+      apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => T,
+      unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)],
+      val query: Query[_, T, Seq])(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _], s20: Shape[_, Rep[A20], A20, _]) extends BaseView[A1, T](tag, name) {
+    def c1 = column[A1](columnNames(0))
+    def c2 = column[A2](columnNames(1))
+    def c3 = column[A3](columnNames(2))
+    def c4 = column[A4](columnNames(3))
+    def c5 = column[A5](columnNames(4))
+    def c6 = column[A6](columnNames(5))
+    def c7 = column[A7](columnNames(6))
+    def c8 = column[A8](columnNames(7))
+    def c9 = column[A9](columnNames(8))
+    def c10 = column[A10](columnNames(9))
+    def c11 = column[A11](columnNames(10))
+    def c12 = column[A12](columnNames(11))
+    def c13 = column[A13](columnNames(12))
+    def c14 = column[A14](columnNames(13))
+    def c15 = column[A15](columnNames(14))
+    def c16 = column[A16](columnNames(15))
+    def c17 = column[A17](columnNames(16))
+    def c18 = column[A18](columnNames(17))
+    def c19 = column[A19](columnNames(18))
+    def c20 = column[A20](columnNames(19))
+
+    override def id = c1
+
+    override protected val columns: Seq[(String, this.type => Rep[_])] = Seq(
+      columnNames(0) -> (_.c1),
+      columnNames(1) -> (_.c2),
+      columnNames(2) -> (_.c3),
+      columnNames(3) -> (_.c4),
+      columnNames(4) -> (_.c5),
+      columnNames(5) -> (_.c6),
+      columnNames(6) -> (_.c7),
+      columnNames(7) -> (_.c8),
+      columnNames(8) -> (_.c9),
+      columnNames(9) -> (_.c10),
+      columnNames(10) -> (_.c11),
+      columnNames(11) -> (_.c12),
+      columnNames(12) -> (_.c13),
+      columnNames(13) -> (_.c14),
+      columnNames(14) -> (_.c15),
+      columnNames(15) -> (_.c16),
+      columnNames(16) -> (_.c17),
+      columnNames(17) -> (_.c18),
+      columnNames(18) -> (_.c19),
+      columnNames(19) -> (_.c20))
+
+    implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20)
+      .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19], Rep[A20]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20), _]]
+
+    def * = (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20) <> (apply.tupled, unapply)
+  }
+
+  def createView[T: ClassTag, E, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, A21: TypedType](name: String,
+    apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => T,
+    unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)],
+    baseQuery: Query[E, _, Seq])(
+      mappings: E => ((String, Rep[A1]), (String, Rep[A2]), (String, Rep[A3]), (String, Rep[A4]), (String, Rep[A5]), (String, Rep[A6]), (String, Rep[A7]), (String, Rep[A8]), (String, Rep[A9]), (String, Rep[A10]), (String, Rep[A11]), (String, Rep[A12]), (String, Rep[A13]), (String, Rep[A14]), (String, Rep[A15]), (String, Rep[A16]), (String, Rep[A17]), (String, Rep[A18]), (String, Rep[A19]), (String, Rep[A20]), (String, Rep[A21])))(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _], s20: Shape[_, Rep[A20], A20, _], s21: Shape[_, Rep[A21], A21, _]): TableQuery[BaseView21[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21]] = {
+
+    var columnsNames = Seq[String]()
+
+    val preparedQuery: Query[_, T, Seq] = {
+      baseQuery.map {
+        t =>
+          mappings(t) match {
+            case ((name1, c1), (name2, c2), (name3, c3), (name4, c4), (name5, c5), (name6, c6), (name7, c7), (name8, c8), (name9, c9), (name10, c10), (name11, c11), (name12, c12), (name13, c13), (name14, c14), (name15, c15), (name16, c16), (name17, c17), (name18, c18), (name19, c19), (name20, c20), (name21, c21)) =>
+              columnsNames = Seq(name1, name2, name3, name4, name5, name6, name7, name8, name9, name10, name11, name12, name13, name14, name15, name16, name17, name18, name19, name20, name21)
+
+              implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21)
+                .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19], Rep[A20], Rep[A21]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21), _]]
+
+              (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21) <> (apply.tupled, unapply)
+          }
+      }
+    }
+    TableQuery.apply(tag => new BaseView21[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](tag, name, columnsNames, apply, unapply, preparedQuery))
+
+  }
+
+  class BaseView21[T: ClassTag, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, A21: TypedType](tag: Tag,
+      name: String,
+      val columnNames: Seq[String],
+      apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => T,
+      unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)],
+      val query: Query[_, T, Seq])(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _], s20: Shape[_, Rep[A20], A20, _], s21: Shape[_, Rep[A21], A21, _]) extends BaseView[A1, T](tag, name) {
+    def c1 = column[A1](columnNames(0))
+    def c2 = column[A2](columnNames(1))
+    def c3 = column[A3](columnNames(2))
+    def c4 = column[A4](columnNames(3))
+    def c5 = column[A5](columnNames(4))
+    def c6 = column[A6](columnNames(5))
+    def c7 = column[A7](columnNames(6))
+    def c8 = column[A8](columnNames(7))
+    def c9 = column[A9](columnNames(8))
+    def c10 = column[A10](columnNames(9))
+    def c11 = column[A11](columnNames(10))
+    def c12 = column[A12](columnNames(11))
+    def c13 = column[A13](columnNames(12))
+    def c14 = column[A14](columnNames(13))
+    def c15 = column[A15](columnNames(14))
+    def c16 = column[A16](columnNames(15))
+    def c17 = column[A17](columnNames(16))
+    def c18 = column[A18](columnNames(17))
+    def c19 = column[A19](columnNames(18))
+    def c20 = column[A20](columnNames(19))
+    def c21 = column[A21](columnNames(20))
+
+    override def id = c1
+
+    override protected val columns: Seq[(String, this.type => Rep[_])] = Seq(
+      columnNames(0) -> (_.c1),
+      columnNames(1) -> (_.c2),
+      columnNames(2) -> (_.c3),
+      columnNames(3) -> (_.c4),
+      columnNames(4) -> (_.c5),
+      columnNames(5) -> (_.c6),
+      columnNames(6) -> (_.c7),
+      columnNames(7) -> (_.c8),
+      columnNames(8) -> (_.c9),
+      columnNames(9) -> (_.c10),
+      columnNames(10) -> (_.c11),
+      columnNames(11) -> (_.c12),
+      columnNames(12) -> (_.c13),
+      columnNames(13) -> (_.c14),
+      columnNames(14) -> (_.c15),
+      columnNames(15) -> (_.c16),
+      columnNames(16) -> (_.c17),
+      columnNames(17) -> (_.c18),
+      columnNames(18) -> (_.c19),
+      columnNames(19) -> (_.c20),
+      columnNames(20) -> (_.c21))
+
+    implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21)
+      .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19], Rep[A20], Rep[A21]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21), _]]
+
+    def * = (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21) <> (apply.tupled, unapply)
+  }
+
+  def createView[T: ClassTag, E, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, A21: TypedType, A22: TypedType](name: String,
+    apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => T,
+    unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)],
+    baseQuery: Query[E, _, Seq])(
+      mappings: E => ((String, Rep[A1]), (String, Rep[A2]), (String, Rep[A3]), (String, Rep[A4]), (String, Rep[A5]), (String, Rep[A6]), (String, Rep[A7]), (String, Rep[A8]), (String, Rep[A9]), (String, Rep[A10]), (String, Rep[A11]), (String, Rep[A12]), (String, Rep[A13]), (String, Rep[A14]), (String, Rep[A15]), (String, Rep[A16]), (String, Rep[A17]), (String, Rep[A18]), (String, Rep[A19]), (String, Rep[A20]), (String, Rep[A21]), (String, Rep[A22])))(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _], s20: Shape[_, Rep[A20], A20, _], s21: Shape[_, Rep[A21], A21, _], s22: Shape[_, Rep[A22], A22, _]): TableQuery[BaseView22[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22]] = {
+
+    var columnsNames = Seq[String]()
+
+    val preparedQuery: Query[_, T, Seq] = {
+      baseQuery.map {
+        t =>
+          mappings(t) match {
+            case ((name1, c1), (name2, c2), (name3, c3), (name4, c4), (name5, c5), (name6, c6), (name7, c7), (name8, c8), (name9, c9), (name10, c10), (name11, c11), (name12, c12), (name13, c13), (name14, c14), (name15, c15), (name16, c16), (name17, c17), (name18, c18), (name19, c19), (name20, c20), (name21, c21), (name22, c22)) =>
+              columnsNames = Seq(name1, name2, name3, name4, name5, name6, name7, name8, name9, name10, name11, name12, name13, name14, name15, name16, name17, name18, name19, name20, name21, name22)
+
+              implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22)
+                .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19], Rep[A20], Rep[A21], Rep[A22]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22), _]]
+
+              (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22) <> (apply.tupled, unapply)
+          }
+      }
+    }
+    TableQuery.apply(tag => new BaseView22[T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22](tag, name, columnsNames, apply, unapply, preparedQuery))
+
+  }
+
+  class BaseView22[T: ClassTag, A1: TypedType, A2: TypedType, A3: TypedType, A4: TypedType, A5: TypedType, A6: TypedType, A7: TypedType, A8: TypedType, A9: TypedType, A10: TypedType, A11: TypedType, A12: TypedType, A13: TypedType, A14: TypedType, A15: TypedType, A16: TypedType, A17: TypedType, A18: TypedType, A19: TypedType, A20: TypedType, A21: TypedType, A22: TypedType](tag: Tag,
+      name: String,
+      val columnNames: Seq[String],
+      apply: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => T,
+      unapply: T => Option[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)],
+      val query: Query[_, T, Seq])(implicit s1: Shape[_, Rep[A1], A1, _], s2: Shape[_, Rep[A2], A2, _], s3: Shape[_, Rep[A3], A3, _], s4: Shape[_, Rep[A4], A4, _], s5: Shape[_, Rep[A5], A5, _], s6: Shape[_, Rep[A6], A6, _], s7: Shape[_, Rep[A7], A7, _], s8: Shape[_, Rep[A8], A8, _], s9: Shape[_, Rep[A9], A9, _], s10: Shape[_, Rep[A10], A10, _], s11: Shape[_, Rep[A11], A11, _], s12: Shape[_, Rep[A12], A12, _], s13: Shape[_, Rep[A13], A13, _], s14: Shape[_, Rep[A14], A14, _], s15: Shape[_, Rep[A15], A15, _], s16: Shape[_, Rep[A16], A16, _], s17: Shape[_, Rep[A17], A17, _], s18: Shape[_, Rep[A18], A18, _], s19: Shape[_, Rep[A19], A19, _], s20: Shape[_, Rep[A20], A20, _], s21: Shape[_, Rep[A21], A21, _], s22: Shape[_, Rep[A22], A22, _]) extends BaseView[A1, T](tag, name) {
+    def c1 = column[A1](columnNames(0))
+    def c2 = column[A2](columnNames(1))
+    def c3 = column[A3](columnNames(2))
+    def c4 = column[A4](columnNames(3))
+    def c5 = column[A5](columnNames(4))
+    def c6 = column[A6](columnNames(5))
+    def c7 = column[A7](columnNames(6))
+    def c8 = column[A8](columnNames(7))
+    def c9 = column[A9](columnNames(8))
+    def c10 = column[A10](columnNames(9))
+    def c11 = column[A11](columnNames(10))
+    def c12 = column[A12](columnNames(11))
+    def c13 = column[A13](columnNames(12))
+    def c14 = column[A14](columnNames(13))
+    def c15 = column[A15](columnNames(14))
+    def c16 = column[A16](columnNames(15))
+    def c17 = column[A17](columnNames(16))
+    def c18 = column[A18](columnNames(17))
+    def c19 = column[A19](columnNames(18))
+    def c20 = column[A20](columnNames(19))
+    def c21 = column[A21](columnNames(20))
+    def c22 = column[A22](columnNames(21))
+
+    override def id = c1
+
+    override protected val columns: Seq[(String, this.type => Rep[_])] = Seq(
+      columnNames(0) -> (_.c1),
+      columnNames(1) -> (_.c2),
+      columnNames(2) -> (_.c3),
+      columnNames(3) -> (_.c4),
+      columnNames(4) -> (_.c5),
+      columnNames(5) -> (_.c6),
+      columnNames(6) -> (_.c7),
+      columnNames(7) -> (_.c8),
+      columnNames(8) -> (_.c9),
+      columnNames(9) -> (_.c10),
+      columnNames(10) -> (_.c11),
+      columnNames(11) -> (_.c12),
+      columnNames(12) -> (_.c13),
+      columnNames(13) -> (_.c14),
+      columnNames(14) -> (_.c15),
+      columnNames(15) -> (_.c16),
+      columnNames(16) -> (_.c17),
+      columnNames(17) -> (_.c18),
+      columnNames(18) -> (_.c19),
+      columnNames(19) -> (_.c20),
+      columnNames(20) -> (_.c21),
+      columnNames(21) -> (_.c22))
+
+    implicit val tupleShape = new TupleShape(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22)
+      .asInstanceOf[Shape[_ <: FlatShapeLevel, (Rep[A1], Rep[A2], Rep[A3], Rep[A4], Rep[A5], Rep[A6], Rep[A7], Rep[A8], Rep[A9], Rep[A10], Rep[A11], Rep[A12], Rep[A13], Rep[A14], Rep[A15], Rep[A16], Rep[A17], Rep[A18], Rep[A19], Rep[A20], Rep[A21], Rep[A22]), (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22), _]]
+
+    def * = (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22) <> (apply.tupled, unapply)
+  }
 }


### PR DESCRIPTION
Add support up to 22 columns (for slick 3.0 migration) and upgrade libraries