### PR TITLE
Introudce variable length json filter fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "org.virtuslab"
 
 name := "beholder"
 
-version := "1.4.1-SNAPSHOT"
+version := "1.4.2-SNAPSHOT"
 
 val scala_2_11 = "2.11.12"
 val scala_2_12 = "2.12.7"

--- a/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilterFieldsComponent.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilterFieldsComponent.scala
@@ -8,8 +8,6 @@ import org.virtuslab.unicorn.UnicornWrapper
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import slick.ast.{ BaseTypedType, TypedType }
-import play.api.libs.json.JodaReads._
-import play.api.libs.json.JodaWrites._
 
 trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersHelperComponent {
   self: UnicornWrapper[Long] =>
@@ -18,29 +16,56 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
   import unicorn.profile.api._
   import CustomTypeMappers._
 
-  abstract class JsonFilterField[A: TypedType, B] extends MappedFilterField[A, B] {
-    def fieldTypeDefinition: JsValue
-
-    protected def filterFormat: Format[B]
-
-    protected[json] def valueWrite: Writes[A]
-
-    final def writeValue(value: Any): JsValue = valueWrite.writes(value.asInstanceOf[A])
-
-    final def readFilter(value: JsValue): JsResult[Any] = filterFormat.reads(value)
-
-    final def writeFilter(value: Any): JsValue = filterFormat.writes(value.asInstanceOf[B])
-
-    def isIgnored = false
+  object SingleFieldTypeDefinition {
+    def get(name: String, label: String, dataType: String): JsObject = {
+      Json.obj(
+        "key" -> JsString(name),
+        "label" -> JsString(label),
+        "type" -> JsString(dataType))
+    }
   }
 
-  abstract class ImplicitlyJsonFilterFiled[A: TypedType: Writes, B: Format](dataTypeName: String)
-    extends JsonFilterField[A, B] {
-    override def fieldTypeDefinition: JsValue = JsString(dataTypeName)
+  trait JsonFieldFormatter {
+    def fieldTypeDefinition(label: String => String): Seq[JsValue]
+    def filterColumnNames: Seq[String]
+    def writeValue(value: Any): JsObject
+    def readFilter(obj: JsObject): JsResult[Option[Any]]
+    def writeFilter(value: Any): JsObject
+  }
 
-    override protected[json] def valueWrite: Writes[A] = implicitly
+  abstract sealed class JsonFilterField[Data: TypedType, Filter] extends MappedFilterField[Data, Filter]
 
-    override protected def filterFormat: Format[B] = implicitly
+  abstract class SingleFieldJsonFilterField[Data: TypedType, Filter] extends JsonFilterField[Data, Filter] {
+    def fieldFormatter(name: String): JsonFieldFormatter
+  }
+
+  abstract class SingleFieldJsonFilterFieldFromFormat[Data: TypedType: Writes, Filter: Format](dataType: String) extends SingleFieldJsonFilterField[Data, Filter] {
+    def formatterFieldTypeDefinition(name: String, label: String => String): Seq[JsValue] = Seq(SingleFieldTypeDefinition.get(name, label(name), dataType))
+    def fieldFormatter(name: String): JsonFieldFormatter = {
+      new JsonFieldFormatter {
+        override def fieldTypeDefinition(label: String => String): Seq[JsValue] = formatterFieldTypeDefinition(name, label)
+        override def filterColumnNames: Seq[String] = Seq(name)
+        override def writeValue(value: Any): JsObject = Json.obj(name -> Json.toJson(value.asInstanceOf[Data]))
+        override def readFilter(obj: JsObject): JsResult[Option[Filter]] = {
+          obj.value.get(name).fold[JsResult[Option[Filter]]](JsSuccess(None))(value => Json.fromJson(value).map(Some(_)))
+        }
+        override def writeFilter(value: Any): JsObject = Json.obj(name -> Json.toJson(value.asInstanceOf[Filter]))
+      }
+    }
+  }
+
+  abstract class VarLengthJsonFilterField[Data: TypedType, Filter](dataType: String, fields: String*) extends JsonFilterField[Data, Filter] {
+    def dataObjWrites: Writes[Data]
+    def filterObjFormat: Format[Filter]
+    val fieldFormatter: JsonFieldFormatter = {
+      new JsonFieldFormatter {
+        override def fieldTypeDefinition(label: String => String): Seq[JsValue] = fields.map(field => SingleFieldTypeDefinition.get(field, label(field), dataType))
+        override def filterColumnNames: Seq[String] = fields
+        override def writeValue(value: Any): JsObject = dataObjWrites.writes(value.asInstanceOf[Data]).asInstanceOf[JsObject]
+        override def readFilter(obj: JsObject): JsResult[Option[Filter]] = JsSuccess(filterObjFormat.reads(obj).asOpt)
+        override def writeFilter(value: Any): JsObject = filterObjFormat.writes(value.asInstanceOf[Filter]).asInstanceOf[JsObject]
+      }
+    }
   }
 
   object JsonFilterFields {
@@ -48,41 +73,41 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
     /**
      * find exact number
      */
-    object inIntField extends ImplicitlyJsonFilterFiled[Int, Int]("Int") {
+    object inIntField extends SingleFieldJsonFilterFieldFromFormat[Int, Int]("Int") {
       override protected def filterOnColumn(column: Rep[Int])(data: Int): Rep[Option[Boolean]] = column.? === data
     }
 
     /**
      * check if value is in given sequence
      */
-    object inIntFieldSeq extends ImplicitlyJsonFilterFiled[Int, Seq[Int]]("IntSeq") {
+    object inIntFieldSeq extends SingleFieldJsonFilterFieldFromFormat[Int, Seq[Int]]("IntSeq") {
       override protected def filterOnColumn(column: Rep[Int])(dataSeq: Seq[Int]): Rep[Option[Boolean]] = {
         SeqParametersHelper.isColumnValueInsideSeq(column)(dataSeq)((column, data) => column.? === data)
       }
     }
 
-    object inBigDecimal extends ImplicitlyJsonFilterFiled[BigDecimal, BigDecimal]("bigDecimal") {
+    object inBigDecimal extends SingleFieldJsonFilterFieldFromFormat[BigDecimal, BigDecimal]("bigDecimal") {
       override protected def filterOnColumn(column: Rep[BigDecimal])(data: BigDecimal): Rep[Option[Boolean]] = column.? === data
     }
 
     /**
      * simple check boolean
      */
-    object inBoolean extends ImplicitlyJsonFilterFiled[Boolean, Boolean]("Boolean") {
+    object inBoolean extends SingleFieldJsonFilterFieldFromFormat[Boolean, Boolean]("Boolean") {
       override def filterOnColumn(column: Rep[Boolean])(data: Boolean): Rep[Option[Boolean]] = column.? === data
     }
 
     /**
      * search in text (ilike)
      */
-    object inText extends ImplicitlyJsonFilterFiled[String, String]("Text") {
+    object inText extends SingleFieldJsonFilterFieldFromFormat[String, String]("Text") {
       override def filterOnColumn(column: Rep[String])(data: String): Rep[Option[Boolean]] = column.? ilike s"%${escape(data)}%"
     }
 
     /**
      * check if text is in given text sequence (ilike)
      */
-    object inTextSeq extends ImplicitlyJsonFilterFiled[String, Seq[String]]("TextSeq") {
+    object inTextSeq extends SingleFieldJsonFilterFieldFromFormat[String, Seq[String]]("TextSeq") {
       override def filterOnColumn(column: Rep[String])(data: Seq[String]): Rep[Option[Boolean]] = {
         SeqParametersHelper.isColumnValueInsideSeq(column)(data)((column, d) => column.? ilike s"%${escape(d)}%")
       }
@@ -91,39 +116,37 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
     /**
      * search in text (ilike) for optional fields
      */
-    object inOptionText extends ImplicitlyJsonFilterFiled[Option[String], String]("OptionalText") {
+    object inOptionText extends SingleFieldJsonFilterFieldFromFormat[Option[String], String]("OptionalText") {
       override def filterOnColumn(column: Rep[Option[String]])(data: String): Rep[Option[Boolean]] = column ilike s"%${escape(data)}%"
     }
 
-    object inDateTime extends ImplicitlyJsonFilterFiled[DateTime, DateTime]("DateTime") {
-      override def filterOnColumn(column: Rep[DateTime])(data: DateTime): Rep[Option[Boolean]] = column.? === data
-
-      override protected[json] def valueWrite: Writes[DateTime] = Writes.jodaDateWrites("yyyy-MM-dd HH:mm")
-
-      override protected def filterFormat: Format[DateTime] = new Format[DateTime] {
-        override def writes(o: DateTime): JsValue = valueWrite.writes(o)
-
-        override def reads(json: JsValue): JsResult[DateTime] = Reads.jodaDateReads("yyyy-MM-dd HH:mm").reads(json)
+    val inDateTime: SingleFieldJsonFilterFieldFromFormat[DateTime, DateTime] = {
+      import play.api.libs.json.JodaReads.jodaDateReads
+      import play.api.libs.json.JodaWrites.jodaDateWrites
+      implicit val format = new Format[DateTime] {
+        override def writes(o: DateTime): JsValue = jodaDateWrites("yyyy-MM-dd HH:mm").writes(o)
+        override def reads(json: JsValue): JsResult[DateTime] = jodaDateReads("yyyy-MM-dd HH:mm").reads(json)
+      }
+      new SingleFieldJsonFilterFieldFromFormat[DateTime, DateTime]("DateTime") {
+        override def filterOnColumn(column: Rep[DateTime])(data: DateTime): Rep[Option[Boolean]] = column.? === data
       }
     }
 
-    object inLocalDate extends ImplicitlyJsonFilterFiled[LocalDate, LocalDate]("LocalDate") {
-      override def filterOnColumn(column: Rep[LocalDate])(data: LocalDate): Rep[Option[Boolean]] = column.? === data
+    val inLocalDate: SingleFieldJsonFilterFieldFromFormat[LocalDate, LocalDate] = {
+      import play.api.libs.json.JodaReads._
+      import play.api.libs.json.JodaWrites._
+      new SingleFieldJsonFilterFieldFromFormat[LocalDate, LocalDate]("LocalDate") {
+        override def filterOnColumn(column: Rep[LocalDate])(data: LocalDate): Rep[Option[Boolean]] = column.? === data
+      }
     }
 
     /**
      * check enum value
      * @tparam T - enum class (eg. Colors.type)
      */
-    def inEnum[T <: Enumeration](enum: T)(implicit tm: BaseTypedType[T#Value], formatter: Format[T#Value]): JsonFilterField[T#Value, T#Value] = {
-      new JsonFilterField[T#Value, T#Value] {
-        override def fieldTypeDefinition: JsValue = JsArray(
-          enum.values.toList.map(v => Json.toJson(v.asInstanceOf[T#Value])))
-
-        override protected[json] def valueWrite: Writes[T#Value] = formatter
-
-        override protected def filterFormat: Format[T#Value] = formatter
-
+    def inEnum[T <: Enumeration](enum: T)(implicit tm: BaseTypedType[T#Value], formatter: Format[T#Value]): SingleFieldJsonFilterFieldFromFormat[T#Value, T#Value] = {
+      new SingleFieldJsonFilterFieldFromFormat[T#Value, T#Value]("") {
+        override def formatterFieldTypeDefinition(name: String, label: String => String): Seq[JsValue] = Seq(JsArray(enum.values.toList.map(v => Json.toJson(v.asInstanceOf[T#Value]))))
         override protected def filterOnColumn(column: Rep[T#Value])(value: T#Value): Rep[Option[Boolean]] = column.? === value
       }
     }
@@ -132,19 +155,13 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
      * check if enum value is in given sequence
      * @tparam T - enum class (eg. Colors.type)
      */
-    def inEnumSeq[T <: Enumeration](enum: T)(implicit tm: BaseTypedType[T#Value], formatter: Format[T#Value]): JsonFilterField[T#Value, Seq[T#Value]] = {
-      new JsonFilterField[T#Value, Seq[T#Value]] {
-        override def fieldTypeDefinition: JsValue = JsArray(
-          enum.values.toList.map(v => Json.toJson(v.asInstanceOf[T#Value])))
-
-        override protected[json] def valueWrite: Writes[T#Value] = formatter
-
-        override protected def filterFormat: Format[Seq[T#Value]] = new Format[Seq[T#Value]] {
-          override def reads(json: JsValue): JsResult[Seq[T#Value]] = JsSuccess(json.as[Seq[T#Value]])
-
-          override def writes(o: Seq[T#Value]): JsValue = JsArray(o.map(Json.toJson(_)))
-        }
-
+    def inEnumSeq[T <: Enumeration](enum: T)(implicit tm: BaseTypedType[T#Value], formatter: Format[T#Value]): SingleFieldJsonFilterFieldFromFormat[T#Value, Seq[T#Value]] = {
+      implicit val format = new Format[Seq[T#Value]] {
+        override def reads(json: JsValue): JsResult[Seq[T#Value]] = JsSuccess(json.as[Seq[T#Value]])
+        override def writes(o: Seq[T#Value]): JsValue = JsArray(o.map(Json.toJson(_)))
+      }
+      new SingleFieldJsonFilterFieldFromFormat[T#Value, Seq[T#Value]]("") {
+        override def formatterFieldTypeDefinition(name: String, label: String => String): Seq[JsValue] = Seq(JsArray(enum.values.toList.map(v => Json.toJson(v.asInstanceOf[T#Value]))))
         override protected def filterOnColumn(column: Rep[T#Value])(dataSeq: Seq[T#Value]): Rep[Option[Boolean]] = {
           SeqParametersHelper.isColumnValueInsideSeq(column)(dataSeq)((column, data) => column.? === data)
         }
@@ -156,19 +173,19 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
         (__ \ "to").formatNullable[T])(FilterRange.apply, unlift(FilterRange.unapply))
 
     def inField[T: BaseTypedType: Format](typeName: String) =
-      new ImplicitlyJsonFilterFiled[T, T](typeName) {
+      new SingleFieldJsonFilterFieldFromFormat[T, T](typeName) {
         override def filterOnColumn(column: Rep[T])(data: T): Rep[Option[Boolean]] = column.? === data
       }
 
     def inFieldSeq[T: BaseTypedType: Format](typeName: String) =
-      new ImplicitlyJsonFilterFiled[T, Seq[T]](typeName) {
+      new SingleFieldJsonFilterFieldFromFormat[T, Seq[T]](typeName) {
         override def filterOnColumn(column: Rep[T])(dataSeq: Seq[T]): Rep[Option[Boolean]] = {
           SeqParametersHelper.isColumnValueInsideSeq(column)(dataSeq)((column, data) => column.? === data)
         }
       }
 
-    def inRange[T: BaseTypedType: Format](baseType: JsonFilterField[T, T]): JsonFilterField[T, FilterRange[T]] =
-      new JsonFilterField[T, FilterRange[T]] {
+    def inRange[T: BaseTypedType: Format](baseType: SingleFieldJsonFilterField[T, T]): SingleFieldJsonFilterFieldFromFormat[T, FilterRange[T]] = {
+      new SingleFieldJsonFilterFieldFromFormat[T, FilterRange[T]]("range") {
         override def filterOnColumn(column: Rep[T])(value: FilterRange[T]): Rep[Option[Boolean]] = {
           value match {
             case FilterRange(Some(from), Some(to)) => column.? >= from && column.? <= to
@@ -177,18 +194,18 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
             case _ => LiteralColumn(Some(true))
           }
         }
-
-        override def fieldTypeDefinition: JsValue = JsObject(Seq(
-          "type" -> JsString("range"),
-          "dataType" -> baseType.fieldTypeDefinition))
-
-        override protected[json] def valueWrite: Writes[T] = baseType.valueWrite
-
-        override protected def filterFormat: Format[FilterRange[T]] = implicitly
+        override def formatterFieldTypeDefinition(name: String, label: String => String): Seq[JsValue] = {
+          super.formatterFieldTypeDefinition(name, label).headOption.map(_.asInstanceOf[JsObject] ++
+            Json.obj("dataType" -> (baseType.fieldFormatter(name).fieldTypeDefinition(label).headOption.getOrElse(JsNull): JsValue))).toSeq
+        }
       }
+    }
 
-    def inOptionRange[T: BaseTypedType: Format](baseType: JsonFilterField[T, T]): JsonFilterField[Option[T], FilterRange[T]] =
-      new JsonFilterField[Option[T], FilterRange[T]] {
+    def inOptionRange[T: BaseTypedType: Format](baseType: SingleFieldJsonFilterField[T, T]): SingleFieldJsonFilterFieldFromFormat[Option[T], FilterRange[T]] = {
+      implicit val optionTWrites: Writes[Option[T]] = new Writes[Option[T]] {
+        override def writes(o: Option[T]) = o.map(implicitly[Writes[T]].writes).getOrElse(JsNull)
+      }
+      new SingleFieldJsonFilterFieldFromFormat[Option[T], FilterRange[T]]("range") {
         override def filterOnColumn(column: Rep[Option[T]])(value: FilterRange[T]): Rep[Option[Boolean]] = {
           value match {
             case FilterRange(Some(from), Some(to)) => column >= from && column <= to
@@ -198,35 +215,27 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
           }
         }
 
-        override def fieldTypeDefinition: JsValue = JsObject(Seq(
-          "type" -> JsString("range"),
-          "dataType" -> baseType.fieldTypeDefinition))
-
-        override protected[json] def valueWrite: Writes[Option[T]] = new Writes[Option[T]] {
-          override def writes(o: Option[T]): JsValue = o.map(baseType.valueWrite.writes).getOrElse(JsNull)
+        override def formatterFieldTypeDefinition(name: String, label: String => String): Seq[JsValue] = {
+          super.formatterFieldTypeDefinition(name, label).headOption.map(_.asInstanceOf[JsObject] ++
+            Json.obj("dataType" -> (baseType.fieldFormatter(name).fieldTypeDefinition(label).headOption.getOrElse(JsNull): JsValue))).toSeq
         }
-
-        override protected def filterFormat: Format[FilterRange[T]] = rangeFormat
       }
+    }
 
     /**
      * Ignores given field in filter.
      */
-    def ignore[T: TypedType: Writes]: JsonFilterField[T, T] = new JsonFilterField[T, T] {
-
-      override def fieldTypeDefinition: JsValue = JsNull
-
-      override protected[json] def valueWrite: Writes[T] = implicitly
-
-      override protected def filterFormat: Format[T] = new Format[T] {
-        override def reads(json: JsValue): JsResult[T] = JsError()
-
-        override def writes(o: T): JsValue = JsNull
+    def ignore[T: TypedType: Writes]: SingleFieldJsonFilterField[T, T] = {
+      new SingleFieldJsonFilterField[T, T] {
+        override def filterOnColumn(column: Rep[T])(value: T): Rep[Option[Boolean]] = LiteralColumn(Some(true))
+        override def fieldFormatter(name: String): JsonFieldFormatter = new JsonFieldFormatter {
+          override def fieldTypeDefinition(label: String => String): Seq[JsValue] = Seq.empty
+          override def filterColumnNames: Seq[String] = Seq(name)
+          override def writeValue(value: Any): JsObject = Json.obj(name -> implicitly[Writes[T]].writes(value.asInstanceOf[T]))
+          override def readFilter(obj: JsObject): JsResult[Option[T]] = JsSuccess(None)
+          override def writeFilter(value: Any): JsObject = Json.obj(name -> implicitly[Writes[T]].writes(value.asInstanceOf[T]))
+        }
       }
-
-      override def filterOnColumn(column: Rep[T])(value: T): Rep[Option[Boolean]] = LiteralColumn(Some(true))
-
-      override def isIgnored: Boolean = true
     }
   }
 }

--- a/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilterFieldsComponent.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/JsonFilterFieldsComponent.scala
@@ -16,7 +16,7 @@ trait JsonFilterFieldsComponent extends FilterFieldComponent with SeqParametersH
   import unicorn.profile.api._
   import CustomTypeMappers._
 
-  object SingleFieldTypeDefinition {
+  private object SingleFieldTypeDefinition {
     def get(name: String, label: String, dataType: String): JsObject = {
       Json.obj(
         "key" -> JsString(name),

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersVarLengthTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersVarLengthTest.scala
@@ -52,7 +52,7 @@ class JsonFiltersVarLengthRepository(override val unicorn: UnicornPlay[Long])
     }
   }
 
-  def createFilter: FilterAPI[UserMachineViewRow, JsonFormatter[UserMachineViewRow]] =
+  def createFilter: FilterAPI[UserMachineViewRow, JsonFormatter[UserMachineViewRow]] = {
     new JsonFilters[UserMachineViewRow](identity).create(
       viewQuery,
       inText,
@@ -61,7 +61,7 @@ class JsonFiltersVarLengthRepository(override val unicorn: UnicornPlay[Long])
       inRange(inField[Date]("date")),
       inOptionRange(inField[BigDecimal]("number")),
       inEnumSeq(MachineStatus))
-
+  }
 }
 
 class JsonFiltersVarLengthTest extends BaseTest with LoneElement {

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersVarLengthTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersVarLengthTest.scala
@@ -1,0 +1,114 @@
+package org.virtuslab.beholder.json
+
+import java.sql.Date
+
+import org.scalatest.LoneElement
+import org.virtuslab.beholder.{ BaseTest, UserMachineViewRow, UserMachinesViewComponent }
+import org.virtuslab.beholder.filters.json.{ JsonFilterFieldsComponent, JsonFiltersComponent, JsonFormatterComponent }
+import org.virtuslab.beholder.model.MachineStatus
+import org.virtuslab.unicorn.{ UnicornPlay, UnicornWrapper }
+import play.api.libs.json.{ Format, JsObject, JsString, JsSuccess, Json, Writes, __ }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class JsonFiltersVarLengthRepository(override val unicorn: UnicornPlay[Long])
+  extends UserMachinesViewComponent
+  with JsonFormatterComponent
+  with JsonFiltersComponent
+  with JsonFilterFieldsComponent
+  with UnicornWrapper[Long] {
+
+  import unicorn.profile.api._
+
+  import JsonFilterFields.{
+    inOptionRange,
+    inText,
+    inIntFieldSeq,
+    inRange,
+    inField,
+    inEnumSeq
+  }
+
+  val inFirstAndSecondPart = new VarLengthJsonFilterField[String, (String, String)]("Text", "firstPart", "secondPart") {
+
+    override val dataObjWrites: Writes[String] = Writes { t: String =>
+      Json.obj(
+        "firstPart" -> JsString(t.substring(0, 3)),
+        "secondPart" -> JsString(t.substring(3, 6)))
+    }
+
+    override val filterObjFormat: Format[(String, String)] = {
+      import play.api.libs.functional.syntax._
+      import play.api.libs.json._
+      (
+        (__ \ 'firstPart).formatWithDefault("") and
+        (__ \ 'secondPart).formatWithDefault("")).tupled
+    }
+
+    override protected def filterOnColumn(column: Rep[String])(value: (String, String)): Rep[Option[Boolean]] = {
+      val (first, second) = value
+      (column.substring(0, 3).? === first) ||
+        (column.substring(3, 6).? === second)
+    }
+  }
+
+  def createFilter: FilterAPI[UserMachineViewRow, JsonFormatter[UserMachineViewRow]] =
+    new JsonFilters[UserMachineViewRow](identity).create(
+      viewQuery,
+      inText,
+      inFirstAndSecondPart,
+      inIntFieldSeq,
+      inRange(inField[Date]("date")),
+      inOptionRange(inField[BigDecimal]("number")),
+      inEnumSeq(MachineStatus))
+
+}
+
+class JsonFiltersVarLengthTest extends BaseTest with LoneElement {
+
+  val jsonFiltersVarLengthRepository = new JsonFiltersVarLengthRepository(unicorn)
+  val baseFilterData = new BaseFilterData
+  import baseFilterData._
+
+  import unicorn.profile.api._
+  class BaseFilterData {
+    lazy val query = userMachinesViewRepository.viewQuery
+    lazy val filter = jsonFiltersVarLengthRepository.createFilter
+    lazy val baseFilter = filter.emptyFilterData
+    lazy val baseFilterData = baseFilter.data
+    lazy val allFromDb: DBIO[Seq[UserMachineViewRow]] =
+      for {
+        view <- userMachinesViewRepository.createUsersMachineView()
+        _ <- populatedDatabase
+        all <- view.result
+      } yield all
+  }
+
+  def doFilter(firstPart: String, secondPart: String): DBIO[Seq[UserMachineViewRow]] = {
+    val filterDefinition = filter.formatter.filterDefinition(
+      Json.obj("data" -> Json.obj("firstPart" -> firstPart, "secondPart" -> secondPart))).get
+    val resultAction = filter.filterWithTotalEntitiesNumber(filterDefinition)
+    resultAction.map {
+      result =>
+        filter.formatter.results(filterDefinition, result) match {
+          case JsObject(fields) =>
+            filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(filterDefinition))
+        }
+        result.content
+    }
+  }
+
+  it should "filter by both splits of column" in rollbackActionWithModel {
+    for {
+      _ <- allFromDb
+      ubu_ntu <- doFilter("Ubu", "ntu")
+      ub_unt <- doFilter("Ub", "unt")
+      fed_ntu <- doFilter("Fed", "ntu")
+    } yield {
+      ubu_ntu.map(_.system).distinct.loneElement shouldEqual "Ubuntu"
+      ub_unt should be(empty)
+      fed_ntu.map(_.system).distinct should contain theSameElementsAs Seq("Ubuntu", "Fedora")
+    }
+  }
+
+}


### PR DESCRIPTION
Introudce variable length json filter fields so we can send filters like
`{ "firstPart": "abc", "secondPart": "bcd" }`
to filter against single column according to custom behavior.