### PR TITLE
Properly escape backslashes in ILikeExtension.escape function

### DIFF
--- a/src/main/scala/org/virtuslab/beholder/utils/ILikeExtension.scala
+++ b/src/main/scala/org/virtuslab/beholder/utils/ILikeExtension.scala
@@ -15,11 +15,13 @@ object ILikeExtension {
   val ILIKE = new SqlOperator("ilike")
 
   /**
-   * escape text so can spoil sql reqexp
-   * @param text
-   * @return
+   * escape underscores, percent signs and backslashes as they have special meaning in PostgreSQL's LIKE function
+   * @see https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
    */
-  def escape(text: String) = text.replace("%", "\\%").replace("_", "\\_")
+  def escape(text: String) = text
+    .replace(raw"\", raw"\\")
+    .replace("%", raw"\%")
+    .replace("_", raw"\_")
 
   implicit def iLikeExtension(c: Rep[String]) = new ILikeExtension(c)
 

--- a/src/test/scala/org/virtuslab/beholder/utils/ILikeExensionTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/utils/ILikeExensionTest.scala
@@ -1,0 +1,32 @@
+package org.virtuslab.beholder.utils
+
+import org.virtuslab.beholder.BaseTest
+
+class ILikeExensionTest extends BaseTest {
+  it should "properly escape underscores, percent signs and backslashes" in { _ =>
+    // GIVEN
+    val troublesomeStrings = Seq(
+      raw"underscore_",
+      raw"percent%",
+      raw"backslash\",
+      raw"double-underscore__",
+      raw"double-percent%%",
+      raw"double-backslash\\",
+      raw"underscore_percent%backslash\")
+
+    // WHEN
+    val escapeResults = troublesomeStrings.map(ILikeExtension.escape)
+
+    // THEN
+    val expectedEscapeResults = Seq(
+      raw"underscore\_",
+      raw"percent\%",
+      raw"backslash\\",
+      raw"double-underscore\_\_",
+      raw"double-percent\%\%",
+      raw"double-backslash\\\\",
+      raw"underscore\_percent\%backslash\\")
+
+    escapeResults shouldEqual expectedEscapeResults
+  }
+}


### PR DESCRIPTION
Right now we are only escaping percent signs (`%`) and underscores (`_`). 
As per [PostgreSQL's documentation][docs], there is one more character with a special meaning — the backslash (`\`) used as an escape character. Since we are always escaping the percent signs and underscores, escaping backslashes shouldn't lose any functionality and will allow us to query for strings such as `abc\x` without having to manually enter `abc\\x`.

[docs]: https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE