### PR TITLE
Add tapir schemas for json filters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json-joda" % "2.9.2",
   "com.h2database" % "h2" % "1.4.200" % "test",
   "com.chuusai"        %% "shapeless" % "2.3.3",
-  "io.underscore"      %% "slickless" % "0.3.6"
+  "io.underscore"      %% "slickless" % "0.3.6",
+  "com.softwaremill.sttp.tapir" %% "tapir-core" % "1.2.7"
 )
 
 testOptions in Test ++= Seq(Tests.Argument("-oF"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.8.2

--- a/src/main/scala/org/virtuslab/beholder/filters/json/JsonFormatterComponent.scala
+++ b/src/main/scala/org/virtuslab/beholder/filters/json/JsonFormatterComponent.scala
@@ -3,6 +3,9 @@ package org.virtuslab.beholder.filters.json
 import org.virtuslab.beholder.filters.{ BaseFilterComponent, FilterDefinition, Order }
 import org.virtuslab.unicorn.UnicornWrapper
 import play.api.libs.json._
+import sttp.tapir.Schema
+import sttp.tapir.SchemaType
+import sttp.tapir.FieldName
 
 trait JsonFormatterComponent extends JsonFilterFieldsComponent with BaseFilterComponent {
   self: UnicornWrapper[Long] =>
@@ -17,6 +20,25 @@ trait JsonFormatterComponent extends JsonFilterFieldsComponent with BaseFilterCo
     def jsonDefinition: JsValue = JsArray {
       fieldFormatters.flatMap(_.fieldTypeDefinition(label))
     }
+    val filterDefinitionSchema: Schema[FilterDefinition] = {
+      implicit val filterDataSchema: Schema[Seq[Option[Any]]] = Schema(SchemaType.SProduct(filterFields.zip(dataColumnsNames).flatMap {
+        case (single: SingleFieldJsonFilterField[_, _], name) => single.filterSchemas(name)
+        case (varLength: VarLengthJsonFilterField[_, _], _) => varLength.filterSchemas("")
+      }.toList))
+      import sttp.tapir.generic.auto._
+
+      Schema(
+        SchemaType.SProduct(
+          List(
+            SchemaType.SProductField(FieldName("take"), Schema.derived[Option[Int]], fd => Some(fd.take)),
+            SchemaType.SProductField(FieldName("skip"), Schema.derived[Option[Int]], fd => Some(fd.skip)),
+            SchemaType.SProductField(FieldName("orderBy"), Schema.derived[Option[Order]], fd => Some(fd.orderBy)),
+            SchemaType.SProductField(FieldName("data"), filterDataSchema, fd => Some(fd.data)),
+          )
+        )
+      )
+    }
+
 
     private val filterDataFormatter: Format[Seq[Option[Any]]] = new Format[Seq[Option[Any]]] {
       override def writes(o: Seq[Option[Any]]): JsValue = {
@@ -58,23 +80,21 @@ trait JsonFormatterComponent extends JsonFilterFieldsComponent with BaseFilterCo
         (__ \ "ordering").formatNullable[Order] and
         (__ \ "data").format(filterDataFormatter))(FilterDefinition.apply, unlift(FilterDefinition.unapply))
 
-    private def entity2Json(data: Entity): JsValue = {
-      fieldFormatters.zip(data.productIterator.toIterable).map {
+    private implicit val entityWrites: Writes[Entity] = Writes { entity: Entity => 
+      fieldFormatters.zip(entity.productIterator.toIterable).map {
         case (formatter, value) => formatter.writeValue(value)
       }.foldLeft(Json.obj())(_ ++ _)
+    }
+
+    final def results(from: FilterDefinition, data: FilterResult[Entity]): JsValue = {
+      Json.toJson(CompoundResult(from, data))
     }
 
     final def filterDefinition(from: JsValue): JsResult[FilterDefinition] = filterDefinitionFormat.reads(from)
 
     final def entities(from: FilterDefinition, data: Seq[Entity]): JsValue = JsObject(Seq(
       "filter" -> Json.toJson(from)(filterDefinitionFormat),
-      "data" -> JsArray(data.map(entity2Json))))
-
-    final def results(from: FilterDefinition, data: FilterResult[Entity]): JsValue = JsObject(Seq(
-      "filter" -> Json.toJson(from)(filterDefinitionFormat),
-      "result" -> JsObject(Seq(
-        "data" -> JsArray(data.content.map(entity2Json)),
-        "total" -> JsNumber(data.total)))))
+      "data" -> JsArray(data.map(entityWrites.writes))))
 
   }
 

--- a/src/test/scala/org/virtuslab/beholder/UserMachinesView.scala
+++ b/src/test/scala/org/virtuslab/beholder/UserMachinesView.scala
@@ -6,6 +6,7 @@ import org.virtuslab.beholder.views.FilterableViewsComponent
 import org.virtuslab.unicorn.{ UnicornPlay, UnicornWrapper }
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import sttp.tapir.Schema
 
 case class UserMachineViewRow(
   email: String,
@@ -21,6 +22,8 @@ trait UserMachinesViewComponent
   self: UnicornWrapper[Long] =>
 
   import unicorn.profile.api._
+
+  implicit val dateSchema: Schema[Date] = Schema.string[Date].format("yyyy-MM-dd")
 
   //query that is a base for view
   lazy val usersMachinesQuery = for {

--- a/src/test/scala/org/virtuslab/beholder/form/FormFiltersTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/form/FormFiltersTest.scala
@@ -207,7 +207,7 @@ class FormFiltersTest extends BaseTest {
         filterData <- filter.filterWithTotalEntitiesNumber(baseFilter.copy(orderBy = Some(Order("cores", asc = false)), skip = Some(1)))
       } yield {
         val fromDbOrderedByCoresDesc = all.sortBy(view => (-view.cores, view.email))
-        filterData.content should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
+        filterData.data should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
         filterData.total shouldEqual all.size
       }
     }

--- a/src/test/scala/org/virtuslab/beholder/form/FormFiltersTestForLargeElements.scala
+++ b/src/test/scala/org/virtuslab/beholder/form/FormFiltersTestForLargeElements.scala
@@ -168,7 +168,7 @@ class FormFiltersTestForLargeElements extends BaseTest {
         filterData <- filter.filterWithTotalEntitiesNumber(baseFilter.copy(orderBy = Some(Order("f1", asc = false)), skip = Some(1)))
       } yield {
         val fromDbOrderedByFirstField = all.sortBy(view => (view.f1)).reverse
-        filterData.content should contain theSameElementsInOrderAs fromDbOrderedByFirstField.drop(1)
+        filterData.data should contain theSameElementsInOrderAs fromDbOrderedByFirstField.drop(1)
         filterData.total shouldEqual all.size
       }
     }

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersEnumTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersEnumTest.scala
@@ -9,6 +9,7 @@ import org.virtuslab.beholder.filters.json.{ JsonFiltersComponent, JsonFormatter
 import org.virtuslab.beholder.model.MachineStatus
 import org.virtuslab.unicorn.{ UnicornPlay, UnicornWrapper }
 import play.api.libs.json.{ JsObject, JsSuccess }
+import sttp.tapir._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -69,7 +70,7 @@ class JsonFiltersEnumTest extends BaseTest {
           case JsObject(fields) =>
             filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(currentFilter))
         }
-        result.content
+        result.data
     }
   }
 

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersRangeTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersRangeTest.scala
@@ -67,7 +67,7 @@ class JsonFiltersRangeTest extends BaseTest {
           case JsObject(fields) =>
             filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(currentFilter))
         }
-        result.content
+        result.data
     }
   }
 

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersSeqTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersSeqTest.scala
@@ -69,7 +69,7 @@ class JsonFiltersSeqTest extends BaseTest {
           case JsObject(fields) =>
             filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(currentFilter))
         }
-        result.content
+        result.data
     }
   }
 

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersTest.scala
@@ -68,7 +68,7 @@ class JsonFiltersTest extends BaseTest {
           case JsObject(fields) =>
             filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(currentFilter))
         }
-        result.content
+        result.data
     }
   }
 
@@ -211,7 +211,7 @@ class JsonFiltersTest extends BaseTest {
         filterData <- filter.filterWithTotalEntitiesNumber(baseFilter.copy(orderBy = Some(Order("cores", asc = false)), skip = Some(1)))
       } yield {
         val fromDbOrderedByCoresDesc = all.sortBy(view => (-view.cores, view.email))
-        filterData.content should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
+        filterData.data should contain theSameElementsInOrderAs fromDbOrderedByCoresDesc.drop(1)
         filterData.total shouldEqual all.size
       }
     }

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersTestForLargeElements.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersTestForLargeElements.scala
@@ -76,7 +76,7 @@ class JsonFiltersTestForLargeElements extends BaseTest {
           case JsObject(fields) =>
             filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(currentFilter))
         }
-        result.content
+        result.data
     }
   }
 
@@ -172,7 +172,7 @@ class JsonFiltersTestForLargeElements extends BaseTest {
         filterData <- filter.filterWithTotalEntitiesNumber(baseFilter.copy(orderBy = Some(Order("f1", asc = false)), skip = Some(1)))
       } yield {
         val fromDbOrderedByFirstField = all.sortBy(view => (view.f1)).reverse
-        filterData.content should contain theSameElementsInOrderAs fromDbOrderedByFirstField.drop(1)
+        filterData.data should contain theSameElementsInOrderAs fromDbOrderedByFirstField.drop(1)
         filterData.total shouldEqual all.size
       }
     }

--- a/src/test/scala/org/virtuslab/beholder/json/JsonFiltersVarLengthTest.scala
+++ b/src/test/scala/org/virtuslab/beholder/json/JsonFiltersVarLengthTest.scala
@@ -10,6 +10,7 @@ import org.virtuslab.unicorn.{ UnicornPlay, UnicornWrapper }
 import play.api.libs.json.{ Format, JsObject, JsString, JsSuccess, Json, Writes, __ }
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import sttp.tapir.SchemaType
 
 class JsonFiltersVarLengthRepository(override val unicorn: UnicornPlay[Long])
   extends UserMachinesViewComponent
@@ -50,6 +51,8 @@ class JsonFiltersVarLengthRepository(override val unicorn: UnicornPlay[Long])
       (column.substring(0, 3).? === first) ||
         (column.substring(3, 6).? === second)
     }
+
+    def filterSchemas(name: String): Seq[SchemaType.SProductField[Seq[Option[Any]]]] = Seq.empty
   }
 
   def createFilter: FilterAPI[UserMachineViewRow, JsonFormatter[UserMachineViewRow]] = {
@@ -93,7 +96,7 @@ class JsonFiltersVarLengthTest extends BaseTest with LoneElement {
           case JsObject(fields) =>
             filter.formatter.filterDefinition(fields("filter")) should equal(JsSuccess(filterDefinition))
         }
-        result.content
+        result.data
     }
   }
 


### PR DESCRIPTION
- Expose raw controller actions underlying doFilter and filterDefinition
- Require schemas for json filter fields
- Create CompoundResult aggregating filter definition and filter results
- Expose schemas for FilterDefinition and CompoundResult